### PR TITLE
Bugfix/incorrect parent recall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.2"
 edition = "2021"
 description = "A transform library to track reference frames and provide transforms between them."
 license = "MIT"
-repository = "https://github.com/dHofmeister/transforms"
+repository = "https://github.com/deniz-hofmeister/transforms"
 
 [features]
 async = ["dep:tokio", "dep:tokio-test"]

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -756,29 +756,18 @@ impl Registry {
         from_chain: &mut VecDeque<Transform>,
         to_chain: &mut VecDeque<Transform>,
     ) {
-        {
-            let from_parents: HashSet<_> = from_chain.iter().map(|tf| &tf.parent).collect();
-
-            if let Some((index, _)) = to_chain
-                .iter()
-                .enumerate()
-                .find(|(_, tf)| from_parents.contains(&tf.parent))
-            {
-                to_chain.truncate(index + 1);
+        let mut start_idx = 0;
+        for (i, j) in from_chain.iter().rev().zip(to_chain.iter().rev()) {
+            if i == j {
+                start_idx += 1;
+            } else {
+                break;
             }
         }
 
-        {
-            let to_parents: HashSet<_> = to_chain.iter().map(|tf| &tf.parent).collect();
-
-            if let Some((index, _)) = from_chain
-                .iter()
-                .enumerate()
-                .find(|(_, tf)| to_parents.contains(&tf.parent))
-            {
-                from_chain.truncate(index + 1);
-            }
-        }
+        // Truncate the chains at the common parent frame
+        from_chain.truncate(from_chain.len() - start_idx);
+        to_chain.truncate(to_chain.len() - start_idx);
     }
 
     /// Combines two transform chains into a single transform representing the transformation from the source frame to the target frame.

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -731,9 +731,9 @@ impl Registry {
                 Ok(tf) => {
                     transforms.push_back(tf.clone());
                     current_frame = tf.parent.clone();
-                    if current_frame == to {
-                        return Ok(transforms);
-                    }
+                    // if current_frame == to {
+                    //     return Ok(transforms);
+                    // }
                 }
                 Err(_) => break,
             }

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -731,9 +731,6 @@ impl Registry {
                 Ok(tf) => {
                     transforms.push_back(tf.clone());
                     current_frame = tf.parent.clone();
-                    // if current_frame == to {
-                    //     return Ok(transforms);
-                    // }
                 }
                 Err(_) => break,
             }

--- a/src/core/registry/tests.rs
+++ b/src/core/registry/tests.rs
@@ -88,6 +88,81 @@ mod registry_tests {
         }
 
         #[test]
+        fn basic_chain_linear_parent() {
+            let _ = env_logger::try_init();
+            let mut registry = Registry::new(Duration::from_secs(10));
+            let t = Timestamp::now();
+
+            // Child frame B at y=1m
+            let t_a_b = Transform {
+                translation: Vector3 {
+                    x: 0.,
+                    y: 1.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "a".into(),
+                child: "b".into(),
+            };
+
+            // Child frame C at x=1m without rotation
+            let t_b_c = Transform {
+                translation: Vector3 {
+                    x: 1.,
+                    y: 0.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "b".into(),
+                child: "c".into(),
+            };
+
+            registry.add_transform(t_a_b.clone()).unwrap();
+            registry.add_transform(t_b_c.clone()).unwrap();
+
+            let t_a_c = Transform {
+                translation: Vector3 {
+                    x: 1.,
+                    y: 1.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "b".into(),
+                child: "c".into(),
+            };
+
+            let r = registry.get_transform("b", "c", t_a_b.timestamp);
+
+            debug!("Result: {:?}", r);
+            debug!("Desired: {:?}", t_a_c);
+
+            assert!(r.is_ok(), "Registry returned Error, expected Ok");
+            assert_eq!(
+                r.unwrap(),
+                t_a_c,
+                "Registry returned a transform that is different"
+            );
+        }
+
+        #[test]
         fn basic_chain_linear_reverse() {
             let _ = env_logger::try_init();
             let mut registry = Registry::new(Duration::from_secs(10));

--- a/src/core/registry/tests.rs
+++ b/src/core/registry/tests.rs
@@ -132,9 +132,9 @@ mod registry_tests {
             registry.add_transform(t_a_b.clone()).unwrap();
             registry.add_transform(t_b_c.clone()).unwrap();
 
-            let t_a_c = Transform {
+            let t_a_b_expected = Transform {
                 translation: Vector3 {
-                    x: 1.,
+                    x: 0.,
                     y: 1.,
                     z: 0.,
                 },
@@ -145,19 +145,19 @@ mod registry_tests {
                     z: 0.,
                 },
                 timestamp: t,
-                parent: "b".into(),
-                child: "c".into(),
+                parent: "a".into(),
+                child: "b".into(),
             };
 
-            let r = registry.get_transform("b", "c", t_a_b.timestamp);
+            let r = registry.get_transform("a", "b", t_a_b.timestamp);
 
             debug!("Result: {:?}", r);
-            debug!("Desired: {:?}", t_a_c);
+            debug!("Desired: {:?}", t_a_b_expected);
 
             assert!(r.is_ok(), "Registry returned Error, expected Ok");
             assert_eq!(
                 r.unwrap(),
-                t_a_c,
+                t_a_b_expected,
                 "Registry returned a transform that is different"
             );
         }
@@ -740,8 +740,8 @@ mod registry_tests {
             registry.add_transform(t_b_c).unwrap();
             registry.add_transform(t_b_d).unwrap();
 
-            let from_chain = Registry::get_transform_chain("d", "a", t, &registry.data);
-            let mut to_chain = Registry::get_transform_chain("c", "a", t, &registry.data);
+            let from_chain = Registry::get_transform_chain("c", "a", t, &registry.data);
+            let mut to_chain = Registry::get_transform_chain("d", "a", t, &registry.data);
 
             if let Ok(chain) = to_chain.as_mut() {
                 Registry::reverse_and_invert_transforms(chain).unwrap();

--- a/src/core/registry/tests.rs
+++ b/src/core/registry/tests.rs
@@ -757,6 +757,27 @@ mod registry_tests {
             let result = Registry::combine_transforms(from, to);
 
             debug!("{:?}", result);
+            assert!(result.is_ok());
+            let t_c_d = result.unwrap();
+
+            let t_c_d_expected = Transform {
+                translation: Vector3 {
+                    x: 1.,
+                    y: 0.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "c".into(),
+                child: "d".into(),
+            };
+
+            assert_eq!(t_c_d, t_c_d_expected);
         }
     }
 }

--- a/src/geometry/point/mod.rs
+++ b/src/geometry/point/mod.rs
@@ -7,8 +7,6 @@ use crate::{
 
 use alloc::string::String;
 
-use super::transform;
-
 mod error;
 
 /// Represents a point in space with a position, orientation, and timestamp.


### PR DESCRIPTION
This pull request includes several important changes to the `transforms` library, focusing on improving the `Registry` implementation, adding tests, and updating the repository URL in the `Cargo.toml` file. Below is a summary of the most significant changes:

### Repository URL Update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L7-R7): Updated the repository URL to the correct GitHub repository.

### Registry Implementation Improvements:
* [`src/core/registry/mod.rs`](diffhunk://#diff-fb3048c56fb1250ad77f3a9672a6619dbfa12f6b4e9392fb69df74f54e225a3dL734-L736): Simplified the logic for truncating transform chains by removing redundant code and using a more efficient approach to find the common parent frame. [[1]](diffhunk://#diff-fb3048c56fb1250ad77f3a9672a6619dbfa12f6b4e9392fb69df74f54e225a3dL734-L736) [[2]](diffhunk://#diff-fb3048c56fb1250ad77f3a9672a6619dbfa12f6b4e9392fb69df74f54e225a3dL759-R767)

### Test Additions and Improvements:
* [`src/core/registry/tests.rs`](diffhunk://#diff-69039545f28ed2084ecb9ee7de32710cc93ac4f90cbc40ca0b5f9f7d65732789R90-R164): Added a new test `basic_chain_linear_parent` to verify the correct behavior of the `Registry` when adding and retrieving transforms in a linear parent-child relationship.
* [`src/core/registry/tests.rs`](diffhunk://#diff-69039545f28ed2084ecb9ee7de32710cc93ac4f90cbc40ca0b5f9f7d65732789L668-R744): Corrected the order of parameters in the `get_transform_chain` function calls and added assertions to check the correctness of the combined transforms. [[1]](diffhunk://#diff-69039545f28ed2084ecb9ee7de32710cc93ac4f90cbc40ca0b5f9f7d65732789L668-R744) [[2]](diffhunk://#diff-69039545f28ed2084ecb9ee7de32710cc93ac4f90cbc40ca0b5f9f7d65732789R760-R780)

### Miscellaneous:
* [`src/geometry/point/mod.rs`](diffhunk://#diff-60f860e40a8de28a63def7a69bc1f4b876cc5795b92a76fbd152329e70adc91dL10-L11): Removed an unused import of the `transform` module.