### PR TITLE
Bugfix/incorrect parent recall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transforms"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A transform library to track reference frames and provide transforms between them."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.2"
 edition = "2021"
 description = "A transform library to track reference frames and provide transforms between them."
 license = "MIT"
-repository = "https://github.com/dHofmeister/transforms"
+repository = "https://github.com/deniz-hofmeister/transforms"
 
 [features]
 async = ["dep:tokio", "dep:tokio-test"]

--- a/examples/full_example.rs
+++ b/examples/full_example.rs
@@ -78,7 +78,7 @@ fn main() {
             info!("Retrieved transform from camera to map: {:?}", transform);
 
             // Apply transform to point
-            match point.transform(&transform) {
+            match point.transform(&transform.inverse().expect("Failed to invert")) {
                 Ok(()) => info!("Successfully transformed point to map frame: {:?}", point),
                 Err(e) => error!("Failed to transform point: {:?}", e),
             }

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -756,29 +756,18 @@ impl Registry {
         from_chain: &mut VecDeque<Transform>,
         to_chain: &mut VecDeque<Transform>,
     ) {
-        {
-            let from_parents: HashSet<_> = from_chain.iter().map(|tf| &tf.parent).collect();
-
-            if let Some((index, _)) = to_chain
-                .iter()
-                .enumerate()
-                .find(|(_, tf)| from_parents.contains(&tf.parent))
-            {
-                to_chain.truncate(index + 1);
+        let mut start_idx = 0;
+        for (i, j) in from_chain.iter().rev().zip(to_chain.iter().rev()) {
+            if i == j {
+                start_idx += 1;
+            } else {
+                break;
             }
         }
 
-        {
-            let to_parents: HashSet<_> = to_chain.iter().map(|tf| &tf.parent).collect();
-
-            if let Some((index, _)) = from_chain
-                .iter()
-                .enumerate()
-                .find(|(_, tf)| to_parents.contains(&tf.parent))
-            {
-                from_chain.truncate(index + 1);
-            }
-        }
+        // Truncate the chains at the common parent frame
+        from_chain.truncate(from_chain.len() - start_idx);
+        to_chain.truncate(to_chain.len() - start_idx);
     }
 
     /// Combines two transform chains into a single transform representing the transformation from the source frame to the target frame.

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -731,9 +731,9 @@ impl Registry {
                 Ok(tf) => {
                     transforms.push_back(tf.clone());
                     current_frame = tf.parent.clone();
-                    if current_frame == to {
-                        return Ok(transforms);
-                    }
+                    // if current_frame == to {
+                    //     return Ok(transforms);
+                    // }
                 }
                 Err(_) => break,
             }

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -168,7 +168,7 @@ use crate::{
     time::Timestamp,
 };
 use alloc::collections::VecDeque;
-use hashbrown::{hash_map::Entry, HashMap, HashSet};
+use hashbrown::{hash_map::Entry, HashMap};
 use std::time::Duration;
 mod error;
 

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -731,9 +731,6 @@ impl Registry {
                 Ok(tf) => {
                     transforms.push_back(tf.clone());
                     current_frame = tf.parent.clone();
-                    // if current_frame == to {
-                    //     return Ok(transforms);
-                    // }
                 }
                 Err(_) => break,
             }

--- a/src/core/registry/tests.rs
+++ b/src/core/registry/tests.rs
@@ -88,6 +88,81 @@ mod registry_tests {
         }
 
         #[test]
+        fn basic_chain_linear_parent() {
+            let _ = env_logger::try_init();
+            let mut registry = Registry::new(Duration::from_secs(10));
+            let t = Timestamp::now();
+
+            // Child frame B at y=1m
+            let t_a_b = Transform {
+                translation: Vector3 {
+                    x: 0.,
+                    y: 1.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "a".into(),
+                child: "b".into(),
+            };
+
+            // Child frame C at x=1m without rotation
+            let t_b_c = Transform {
+                translation: Vector3 {
+                    x: 1.,
+                    y: 0.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "b".into(),
+                child: "c".into(),
+            };
+
+            registry.add_transform(t_a_b.clone()).unwrap();
+            registry.add_transform(t_b_c.clone()).unwrap();
+
+            let t_a_c = Transform {
+                translation: Vector3 {
+                    x: 1.,
+                    y: 1.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "b".into(),
+                child: "c".into(),
+            };
+
+            let r = registry.get_transform("b", "c", t_a_b.timestamp);
+
+            debug!("Result: {:?}", r);
+            debug!("Desired: {:?}", t_a_c);
+
+            assert!(r.is_ok(), "Registry returned Error, expected Ok");
+            assert_eq!(
+                r.unwrap(),
+                t_a_c,
+                "Registry returned a transform that is different"
+            );
+        }
+
+        #[test]
         fn basic_chain_linear_reverse() {
             let _ = env_logger::try_init();
             let mut registry = Registry::new(Duration::from_secs(10));

--- a/src/core/registry/tests.rs
+++ b/src/core/registry/tests.rs
@@ -132,9 +132,9 @@ mod registry_tests {
             registry.add_transform(t_a_b.clone()).unwrap();
             registry.add_transform(t_b_c.clone()).unwrap();
 
-            let t_a_c = Transform {
+            let t_a_b_expected = Transform {
                 translation: Vector3 {
-                    x: 1.,
+                    x: 0.,
                     y: 1.,
                     z: 0.,
                 },
@@ -145,19 +145,19 @@ mod registry_tests {
                     z: 0.,
                 },
                 timestamp: t,
-                parent: "b".into(),
-                child: "c".into(),
+                parent: "a".into(),
+                child: "b".into(),
             };
 
-            let r = registry.get_transform("b", "c", t_a_b.timestamp);
+            let r = registry.get_transform("a", "b", t_a_b.timestamp);
 
             debug!("Result: {:?}", r);
-            debug!("Desired: {:?}", t_a_c);
+            debug!("Desired: {:?}", t_a_b_expected);
 
             assert!(r.is_ok(), "Registry returned Error, expected Ok");
             assert_eq!(
                 r.unwrap(),
-                t_a_c,
+                t_a_b_expected,
                 "Registry returned a transform that is different"
             );
         }
@@ -740,8 +740,8 @@ mod registry_tests {
             registry.add_transform(t_b_c).unwrap();
             registry.add_transform(t_b_d).unwrap();
 
-            let from_chain = Registry::get_transform_chain("d", "a", t, &registry.data);
-            let mut to_chain = Registry::get_transform_chain("c", "a", t, &registry.data);
+            let from_chain = Registry::get_transform_chain("c", "a", t, &registry.data);
+            let mut to_chain = Registry::get_transform_chain("d", "a", t, &registry.data);
 
             if let Ok(chain) = to_chain.as_mut() {
                 Registry::reverse_and_invert_transforms(chain).unwrap();

--- a/src/core/registry/tests.rs
+++ b/src/core/registry/tests.rs
@@ -757,6 +757,27 @@ mod registry_tests {
             let result = Registry::combine_transforms(from, to);
 
             debug!("{:?}", result);
+            assert!(result.is_ok());
+            let t_c_d = result.unwrap();
+
+            let t_c_d_expected = Transform {
+                translation: Vector3 {
+                    x: 1.,
+                    y: 0.,
+                    z: 0.,
+                },
+                rotation: Quaternion {
+                    w: 1.,
+                    x: 0.,
+                    y: 0.,
+                    z: 0.,
+                },
+                timestamp: t,
+                parent: "c".into(),
+                child: "d".into(),
+            };
+
+            assert_eq!(t_c_d, t_c_d_expected);
         }
     }
 }

--- a/src/geometry/point/mod.rs
+++ b/src/geometry/point/mod.rs
@@ -7,8 +7,6 @@ use crate::{
 
 use alloc::string::String;
 
-use super::transform;
-
 mod error;
 
 /// Represents a point in space with a position, orientation, and timestamp.

--- a/src/geometry/point/mod.rs
+++ b/src/geometry/point/mod.rs
@@ -128,20 +128,18 @@ impl Transformable for Point {
         &mut self,
         transform: &Transform,
     ) -> Result<(), TransformError> {
-        let tf = transform.inverse()?;
-
-        if self.frame != tf.child {
+        if self.frame != transform.child {
             return Err(TransformError::IncompatibleFrames);
         }
-        if self.timestamp != tf.timestamp {
+        if self.timestamp != transform.timestamp {
             return Err(TransformError::TimestampMismatch(
                 self.timestamp.nanoseconds as f64,
-                tf.timestamp.nanoseconds as f64,
+                transform.timestamp.nanoseconds as f64,
             ));
         }
-        self.position = tf.rotation.rotate_vector(self.position) + tf.translation;
-        self.orientation = tf.rotation * self.orientation;
-        self.frame = tf.parent.clone();
+        self.position = transform.rotation.rotate_vector(self.position) + transform.translation;
+        self.orientation = transform.rotation * self.orientation;
+        self.frame = transform.parent.clone();
         Ok(())
     }
 }

--- a/src/geometry/point/mod.rs
+++ b/src/geometry/point/mod.rs
@@ -7,6 +7,8 @@ use crate::{
 
 use alloc::string::String;
 
+use super::transform;
+
 mod error;
 
 /// Represents a point in space with a position, orientation, and timestamp.
@@ -126,18 +128,20 @@ impl Transformable for Point {
         &mut self,
         transform: &Transform,
     ) -> Result<(), TransformError> {
-        if self.frame != transform.child {
+        let tf = transform.inverse()?;
+
+        if self.frame != tf.child {
             return Err(TransformError::IncompatibleFrames);
         }
-        if self.timestamp != transform.timestamp {
+        if self.timestamp != tf.timestamp {
             return Err(TransformError::TimestampMismatch(
                 self.timestamp.nanoseconds as f64,
-                transform.timestamp.nanoseconds as f64,
+                tf.timestamp.nanoseconds as f64,
             ));
         }
-        self.position = transform.rotation.rotate_vector(self.position) + transform.translation;
-        self.orientation = transform.rotation * self.orientation;
-        self.frame = transform.parent.clone();
+        self.position = tf.rotation.rotate_vector(self.position) + tf.translation;
+        self.orientation = tf.rotation * self.orientation;
+        self.frame = tf.parent.clone();
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request includes several updates to the `transforms` library, focusing on improving the accuracy of transformations and enhancing the test coverage. The most important changes include updating the version and repository URL in `Cargo.toml`, modifying the transformation logic, and adding new tests to validate the changes.

### Updates to `Cargo.toml`:

* Updated the version from `0.3.1` to `0.3.2` and corrected the repository URL.

### Transformation Logic Improvements:

* Modified the transformation application in `examples/full_example.rs` to use the inverse of the transform.
* Simplified the logic for truncating transform chains in `src/core/registry/mod.rs`.
* Removed redundant condition checks in the `Registry` implementation.

### Enhanced Test Coverage:

* Added a new test `basic_chain_linear_parent` to validate the transformation chain logic.
* Corrected the order of transformation chains in existing tests and added assertions to validate the combined transforms. [[1]](diffhunk://#diff-69039545f28ed2084ecb9ee7de32710cc93ac4f90cbc40ca0b5f9f7d65732789L668-R744) [[2]](diffhunk://#diff-69039545f28ed2084ecb9ee7de32710cc93ac4f90cbc40ca0b5f9f7d65732789R760-R780)