### PR TITLE
Extend the verification gate to robotics MCU targets and ARM64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,15 @@ jobs:
         run: cargo clippy --all-targets --no-default-features -- -D warnings
 
   tests:
-    name: tests
-    runs-on: ubuntu-latest
+    name: tests (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # The full suite executes natively on both deployment
+        # architectures: x86_64 (dev machines, industrial PCs) and ARM64
+        # (Raspberry Pi, NVIDIA Jetson).
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
@@ -59,8 +66,12 @@ jobs:
         run: cargo test --no-default-features
 
   serde:
-    name: serde
-    runs-on: ubuntu-latest
+    name: serde (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
@@ -132,17 +143,31 @@ jobs:
         run: cargo bench --no-default-features -- --test
 
   bare-metal:
-    name: bare-metal
+    name: bare-metal (${{ matrix.target }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          # STM32 F4/F7/H7, nRF52, Teensy 4 — Cortex-M4F/M7, the dominant
+          # flight-controller class (PX4/Pixhawk, ArduPilot, Betaflight).
+          - thumbv7em-none-eabihf
+          # RP2040 / Raspberry Pi Pico — Cortex-M0+: soft float and no
+          # compare-and-swap atomics, the strictest portability check.
+          - thumbv6m-none-eabi
+          # RP2350, nRF5340, STM32 H5/U5 — Cortex-M33, current generation.
+          - thumbv8m.main-none-eabihf
+          # ESP32-C3/C6, GD32V — RISC-V, guards against ARM-only assumptions.
+          - riscv32imc-unknown-none-elf
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
           toolchain: stable
       - name: Install bare-metal target
-        run: rustup target add thumbv7em-none-eabihf
-      - name: Build for thumbv7em-none-eabihf
-        run: cargo build --no-default-features --target thumbv7em-none-eabihf
+        run: rustup target add ${{ matrix.target }}
+      - name: Build for ${{ matrix.target }}
+        run: cargo build --no-default-features --target ${{ matrix.target }}
 
   security:
     name: security

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,13 @@ Its priorities, in this order:
   for benches, `proptest` for property tests, `serde_json` for serde
   roundtrips — are expected and do not contradict this.)
 - `no_std` parity: every change must build and pass tests with
-  `--no-default-features`, and build for a real bare-metal target (the gate
-  builds `thumbv7em-none-eabihf`). `no_std` requires a heap allocator (`alloc`).
+  `--no-default-features`, and build for real bare-metal targets: the gate
+  builds `thumbv7em-none-eabihf` (Cortex-M4F/M7 — STM32 F4/F7/H7 flight
+  controllers), `thumbv6m-none-eabi` (Cortex-M0+ — RP2040; soft float, no
+  compare-and-swap atomics), and `thumbv8m.main-none-eabihf` (Cortex-M33 —
+  RP2350, STM32 H5/U5); CI additionally builds
+  `riscv32imc-unknown-none-elf` (ESP32-C3/C6). `no_std` requires a heap
+  allocator (`alloc`).
   Features must be additive: the same API exists in both modes; the only
   feature-gated items are `Timestamp::now()`, the `SystemTime` time type
   (`std`), and the serde derives (`serde`, default-off).
@@ -168,11 +173,16 @@ cargo run --example no_std_minimal --no-default-features   # and the other no_st
 cargo bench -- --test
 cargo bench --no-default-features -- --test         # CI also builds no_std benches
 cargo build --no-default-features --target thumbv7em-none-eabihf   # real no_std proof
+cargo build --no-default-features --target thumbv6m-none-eabi      # Cortex-M0+: soft float, no CAS
+cargo build --no-default-features --target thumbv8m.main-none-eabihf
 ```
 
-(`rustup target add thumbv7em-none-eabihf` once, if the target is missing.)
-CI additionally checks the MSRV (`cargo check` on Rust 1.86) and runs
-`cargo audit` against the RustSec advisory database.
+(`rustup target add <target>` once per target, if missing. CI also builds
+`riscv32imc-unknown-none-elf`.)
+CI additionally runs the test suite natively on ARM64 as well as x86_64
+(the Raspberry Pi / Jetson deployment class), checks the MSRV
+(`cargo check` on Rust 1.86), and runs `cargo audit` against the RustSec
+advisory database.
 
 Docs are part of the change: the README (API Reference, What's New, examples
 table) and rustdoc must be updated in the same commit as the code they

--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Full version history lives in [CHANGELOG.md](CHANGELOG.md).
   values, unit rotations), the frame tree is strict (single pinned parent,
   no cycles), and lookups either answer the exact question asked or return an
   error — the silent-wrong-answer failure modes of 1.x are gone.
-- **Real `no_std`**: builds for bare-metal targets (CI proves it on
-  `thumbv7em-none-eabihf`); the `std` feature is additive, and automatic
-  cleanup (`with_max_age`) works in both modes.
+- **Tested on deployment architectures**: CI executes the full test suite
+  natively on x86_64 and ARM64 (Raspberry Pi, NVIDIA Jetson).
+- **Real `no_std`**: builds for bare-metal targets — CI proves it on
+  `thumbv7em-none-eabihf` (STM32 F4/F7/H7 flight controllers),
+  `thumbv6m-none-eabi` (RP2040), `thumbv8m.main-none-eabihf` (Cortex-M33),
+  and `riscv32imc-unknown-none-elf` (ESP32-C3) — the `std` feature is
+  additive, and automatic cleanup (`with_max_age`) works in both modes.
 - **Rust-first API cleanup**: exact `==` with tolerant comparison in the
   `approx` traits, `#[non_exhaustive]` errors, private internals, optional
   `serde` support, an enforced panic policy, and MSRV 1.86.

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -21,3 +21,5 @@ cargo run --example std_advanced
 cargo bench --no-default-features -- --test
 cargo bench -- --test
 cargo build --no-default-features --target thumbv7em-none-eabihf
+cargo build --no-default-features --target thumbv6m-none-eabi
+cargo build --no-default-features --target thumbv8m.main-none-eabihf


### PR DESCRIPTION
## Summary

Extends the verification gate to the architectures robotics and drones actually ship on.

**In this push** (`tests/test_all.sh`, `AGENTS.md`, `README.md`):
- The local gate builds two more bare-metal targets alongside `thumbv7em-none-eabihf` (STM32 F4/F7/H7 — the dominant flight-controller class): `thumbv6m-none-eabi` (RP2040 / Pi Pico — Cortex-M0+, soft float, no compare-and-swap atomics, the strictest portability check) and `thumbv8m.main-none-eabihf` (Cortex-M33 — RP2350, nRF5340, STM32 H5/U5). Both verified building clean locally.
- Docs describe the full matrix including `riscv32imc-unknown-none-elf` (ESP32-C3/C6) and native ARM64 test execution.

**Pending one manual commit by the maintainer** — `.github/workflows/tests.yml`: the push token lacks the `workflow` scope GitHub requires for CI edits (both git push and the REST API reject it), so the finished file is applied through the web editor on this branch. It converts the `bare-metal` job into the four-target matrix above and runs the `tests` and `serde` jobs on a runner matrix of `ubuntu-latest` + `ubuntu-24.04-arm`, so the full suite executes natively on the Raspberry Pi / Jetson architecture.

No library code changes and deliberately **no version bump** — these changes ride along in the next release, like the dependabot CI bumps.

> Stacked on #90 (base `bugfix/docs-std-variants`); merge chain is #89 → #90 → this. Auto-retargets as the chain merges.

## Testing

- `cargo build --no-default-features --target thumbv6m-none-eabi` and `--target thumbv8m.main-none-eabihf` locally (the riscv target gets its first verification from this PR's CI once the workflow commit lands)
- `bash -n tests/test_all.sh`; workflow YAML validated with a YAML parser

## AI disclosure

This change was implemented with AI assistance (Claude); the commit carries the `Assisted-by: Claude:claude-fable-5` trailer per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)