### PR TITLE
Make the gate nightly-only and independent of rustup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,13 @@ this section is convention, enforced in review — follow it anyway.
 ## Definition of done — the verification gate
 
 All of the following must pass before a change is complete
-(`tests/test_all.sh` runs the whole gate):
+(`tests/test_all.sh` runs the whole gate). The gate requires a **nightly**
+toolchain and crashes explicitly otherwise: rustfmt.toml uses nightly-only
+options, and one pinned toolchain keeps the gate identical on every machine
+(rustup, Nix, or distro-packaged Rust). Stable and MSRV verification is
+CI's job, and nightly clippy diverges from CI's stable clippy only in the
+safe direction — it is a superset, so a green local gate implies green CI
+clippy:
 
 ```bash
 cargo test
@@ -166,7 +172,7 @@ cargo test --features serde
 cargo test --no-default-features --features serde
 cargo clippy --all-targets -- -D warnings
 cargo clippy --all-targets --no-default-features -- -D warnings
-rustup run nightly cargo fmt --check                # repo uses nightly rustfmt options
+cargo fmt --check                                   # nightly rustfmt (see above)
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 cargo run --example std_minimal                     # and the other std examples
 cargo run --example no_std_minimal --no-default-features   # and the other no_std examples
@@ -177,7 +183,8 @@ cargo build --no-default-features --target thumbv6m-none-eabi      # Cortex-M0+:
 cargo build --no-default-features --target thumbv8m.main-none-eabihf
 ```
 
-(`rustup target add <target>` once per target, if missing. CI also builds
+(On rustup machines: `rustup run nightly tests/test_all.sh`, and
+`rustup target add <target>` once per target, if missing. CI also builds
 `riscv32imc-unknown-none-elf`.)
 CI additionally runs the test suite natively on ARM64 as well as x86_64
 (the Raspberry Pi / Jetson deployment class), checks the MSRV

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 # The full verification gate for this repository; see AGENTS.md "Definition of done".
+#
+# The gate runs on nightly: rustfmt.toml uses nightly-only options, and one
+# pinned toolchain keeps the gate identical on every machine regardless of
+# how Rust was installed (rustup, Nix, distro package). Stable and MSRV
+# coverage is CI's job (.github/workflows/tests.yml).
 set -e
+
+rustc --version | grep -q nightly || {
+    echo "error: the gate requires a nightly toolchain" >&2
+    echo "  rustup machines: rustup run nightly tests/test_all.sh" >&2
+    exit 1
+}
 
 cargo build --no-default-features
 cargo build
@@ -10,7 +21,7 @@ cargo test --no-default-features --features serde
 cargo test
 cargo clippy --all-targets --no-default-features -- -D warnings
 cargo clippy --all-targets -- -D warnings
-rustup run nightly cargo fmt --check
+cargo fmt --check
 RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 cargo run --example no_std_minimal --no-default-features
 cargo run --example no_std_full --no-default-features
@@ -23,3 +34,7 @@ cargo bench -- --test
 cargo build --no-default-features --target thumbv7em-none-eabihf
 cargo build --no-default-features --target thumbv6m-none-eabi
 cargo build --no-default-features --target thumbv8m.main-none-eabihf
+
+# Printed only if every step above succeeded; a truncated run can never be
+# mistaken for a pass even when the exit code is swallowed by a pipeline.
+echo "GATE PASSED (all steps completed)"


### PR DESCRIPTION
## Summary

`tests/test_all.sh` called `rustup run nightly` for the fmt check; on machines where Rust arrives without rustup (Nix, distro packages) that line died with exit 127 under `set -e`, silently skipping the 13 gate steps after it — and piping the output (`| tail`) masked even the exit code, letting an aborted gate read as a pass. The verification gate exhibited this repo's own declared worst failure mode: a silent wrong answer.

The fix declares one toolchain instead of branching per environment:

- The gate **requires nightly** and crashes explicitly with instructions otherwise (`rustup machines: rustup run nightly tests/test_all.sh`). Nightly was already forced in practice by rustfmt.toml's nightly-only options.
- The fmt step is plain `cargo fmt --check`; the script never calls rustup, so it behaves identically however Rust was installed.
- A final `GATE PASSED (all steps completed)` marker makes a truncated run visually distinguishable from a completed one even when the exit code is swallowed by a pipeline.
- AGENTS.md documents the design: local gate = nightly, identical everywhere; stable + MSRV verification = CI's job; nightly clippy is a superset of CI's stable clippy, so the divergence runs only in the safe direction.

Repo tooling only — no library code, no version bump.

## Testing

- Full `tests/test_all.sh` executed end-to-end on a rustup-less nightly machine (Nix): all steps pass, `GATE PASSED` printed — the first complete run of this script in that environment.
- Crash path verified with a PATH-shimmed stable `rustc`: explicit error message, exit 1.
- `bash -n` syntax check.

## AI disclosure

This change was implemented with AI assistance (Claude); the commit carries the `Assisted-by: Claude:claude-fable-5` trailer per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)