### PR TITLE
Pre-tag punch list and the rotation-algebra surface cut

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ this section is convention, enforced in review — follow it anyway.
   `Transform::new(parent, child, translation, rotation, stamp)` /
   `Transform::static_between(..)` (both fallible),
   `Point::new(position, orientation, timestamp, frame)`,
-  `Vector3::new/zero/unit_*`, `Quaternion::from_wxyz(w, x, y, z)` /
+  `Vector3::new/zero`, `Quaternion::from_wxyz(w, x, y, z)` /
   `Quaternion::identity()`, `Timestamp::zero()` / `Timestamp::from_nanos()`.
   `Transform` and `Point` are `#[non_exhaustive]`; `Transform`'s fields are
   private, and a test that needs a deliberately invalid transform uses the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,12 +353,27 @@ describe. Documentation drift is treated as a bug.
 
 ## Releasing
 
-Releases are cut by the maintainer. The checklist, in order:
+Releases are cut by the maintainer. Release prep is ordinary branch work:
+it lands on master through the usual branch-and-merge flow before anything
+is tagged, and the tag goes on master — `cargo publish` then runs from the
+tagged tree. The checklist, in order:
 
 - Finalize `CHANGELOG.md`: replace the version's `Unreleased` marker with the
-  release date and repoint its compare link to the tag.
-- Confirm the `version` in `Cargo.toml` matches the release, and bump the
-  version pins in the README installation snippets.
+  release date and repoint its compare link to the tag. For 2.0.0 stable
+  specifically, this step is also the consolidation, and it must happen
+  here — before the tag and the publish, never after: `CHANGELOG.md` and
+  `MIGRATION.md` ship inside the `.crate`, and a published crate is
+  immutable. Fold the five published pre-release sections (alpha.1,
+  beta.1–beta.4) and the never-published rc.2 section into a single
+  `[2.0.0]` section organized by Keep-a-Changelog categories, give it the
+  one compare link `v1.4.1...v2.0.0`, resolve the cross-references the
+  fold orphans — entries pointing at per-pre-release sections, or at the
+  never-published rc.2 — and verify `MIGRATION.md` against the result.
+- Confirm the `version` in `Cargo.toml` matches the release, regenerate
+  `Cargo.lock` so it records that version (any `cargo build` after the
+  bump does), and bump the version pins in the README installation
+  snippets — all committed together: `cargo publish` refuses a dirty
+  tree.
 - Run the full verification gate (`tests/test_all.sh`).
 - Run `cargo semver-checks check-release --baseline-rev <previous tag>` and
   confirm the diff is exactly the changelogged one. Against a baseline the
@@ -370,13 +385,13 @@ Releases are cut by the maintainer. The checklist, in order:
   the baseline.
 - `cargo publish --dry-run` and inspect the file list — nothing missing,
   nothing that should not ship.
-- Tag `vX.Y.Z` and push the tag.
+- Merge the release-prep branch to master. If the merge is not a
+  fast-forward, re-run the gate on it — the tag must point at a tree the
+  gate has seen.
+- Tag `vX.Y.Z` on the merge and push the tag.
 - `cargo publish`.
-- Create a GitHub release for the tag (pre-releases marked as such).
-- For 2.0.0 stable specifically: consolidate the alpha/beta pre-release
-  entries into a single `[2.0.0]` changelog section organized by
-  Keep-a-Changelog categories, verify `MIGRATION.md` against it, and mark
-  the GitHub release as latest.
+- Create a GitHub release for the tag (pre-releases marked as such). For
+  2.0.0 stable specifically: mark it as latest.
 - After 2.0.0 is published: add a `cargo-semver-checks` CI job so accidental
   breaking changes are caught against the published baseline. This is
   deliberately not added pre-release — everything is breaking against 1.4.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,6 +394,12 @@ and this section is the whole delta from beta.4.
   opts into `doc(auto_cfg)` for future rustdoc support); the
   `no_std_full` example imports `core::time::Duration` in its `no_std`
   branch; the buffer docs say B-tree instead of "binary tree".
+- Docs: MIGRATION.md names all five published 2.x pre-releases — alpha.1
+  and beta.1 through beta.4; it previously claimed beta.4 was the only
+  one — and stands alone: its changelog pointers survive the
+  consolidation that cuts 2.0.0 stable. Runtime changes 3 and 5 now cover
+  `get_transform_at`'s coinciding-frame legs and the expiry-reference
+  reset, and the beta.4 delta gains the frame-keeping wipe.
 - CHANGELOG: the beta.3 entry called the removed `TransformError::NotFound`
   "never-produced". That was wrong — it was the primary 1.x lookup-miss
   error and beta.1/beta.2 still produced it; the entry below is corrected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,6 +400,14 @@ and this section is the whole delta from beta.4.
   consolidation that cuts 2.0.0 stable. Runtime changes 3 and 5 now cover
   `get_transform_at`'s coinciding-frame legs and the expiry-reference
   reset, and the beta.4 delta gains the frame-keeping wipe.
+- Docs: `Transformable` states the map an implementation owes — rotate,
+  then translate; orientation composed with the transform's rotation on
+  the left; a free vector takes the rotation only — previously readable
+  solely in `Point`'s source, and README's trait section points at it.
+  The flipped orientation order was invisible to the whole suite (every
+  stored fixture orientation was the identity); a `Point` test now starts
+  from a non-commuting orientation and pins the left composition against
+  hand-derived digits.
 - CHANGELOG: the beta.3 entry called the removed `TransformError::NotFound`
   "never-produced". That was wrong — it was the primary 1.x lookup-miss
   error and beta.1/beta.2 still produced it; the entry below is corrected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,19 @@ and this section is the whole delta from beta.4.
 - **Breaking:** `UNIT_NORM_TOLERANCE` is a module-level const
   (re-exported at `geometry::UNIT_NORM_TOLERANCE`) instead of an
   associated const on `Transform<T>` that demanded a turbofish.
+- **Breaking:** `Quaternion` keeps only its rotation algebra — `*`,
+  `conjugate`, `normalize`, `norm`, `rotate_vector`, `slerp` and the
+  constructors. The vector-space surface leaves the public API: `+`, `-`,
+  `/` (with its `QuaternionError::DivisionByZero`) and the `Default` impl
+  had no caller outside their own unit tests, `norm_squared` served only
+  the removed `/`, and `scale` survives privately inside `normalize` and
+  `slerp`. Summing rotations and renormalizing is the classic silent
+  wrong answer, and `/` returned `Ok` with all-NaN components for a NaN
+  divisor and an all-zero, finite quaternion for an overflowing one.
+  `q2 / q1` on unit quaternions is `q2 * q1.conjugate()` up to the
+  divisor's norm drift — the conjugate spelling is the more accurate.
+  Slerp's blend moved to a private helper, unchanged bit for bit under
+  the existing pins.
 - `get_transform_at` composes its two legs through a private
   time-agnostic path instead of fabricating staticness on them to bypass
   `Mul`'s timestamp check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,7 +407,10 @@ and this section is the whole delta from beta.4.
 - AGENTS.md: the normative lookup invariant referenced the removed
   `NotFound` variant; it now names `UnknownFrame` / `Disconnected` /
   `NotFoundAt`. The release checklist loses a garbled fragment and gains
-  the consolidation, semver-check, README-pin, and GitHub-release steps.
+  the consolidation — in the finalize step, ahead of the immutable tag
+  and publish, resolving the cross-references the fold orphans — plus the
+  semver-check, README-pin, GitHub-release, lockfile-regeneration, and
+  merge-before-tag steps.
 
 ## [2.0.0-beta.4] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,12 @@ and this section is the whole delta from beta.4.
   divisor's norm drift — the conjugate spelling is the more accurate.
   Slerp's blend moved to a private helper, unchanged bit for bit under
   the existing pins.
+- **Breaking:** `Vector3` loses `dot`, `cross` and
+  `unit_x`/`unit_y`/`unit_z` — `dot` and `cross` were exercised only by
+  their own unit tests, the unit constructors by nothing at all, the
+  crate already points more general needs at a linear-algebra library,
+  and the public components make each a one-liner. The operator set
+  stays complete: `+`, `-`, both scalar multiplications and `/` remain.
 - `get_transform_at` composes its two legs through a private
   time-agnostic path instead of fabricating staticness on them to bypass
   `Mul`'s timestamp check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,6 +408,14 @@ and this section is the whole delta from beta.4.
   stored fixture orientation was the identity); a `Point` test now starts
   from a non-commuting orientation and pins the left composition against
   hand-derived digits.
+- Docs: `RegistryError::NotFoundAt` documents the terminating
+  latest-available retry idiom — re-ask at the covered range's end only
+  while that end is older than the request — with a runnable example, and
+  `get_transform` and MIGRATION.md point at it. The unguarded version
+  oscillates forever between two hops with disjoint coverage. The guard
+  is exact for a root target; for a mid-tree target the walks can report
+  edges above the frames' common ancestor, making the loop conservative.
+  A property test pins the root-target exactness.
 - CHANGELOG: the beta.3 entry called the removed `TransformError::NotFound`
   "never-produced". That was wrong — it was the primary 1.x lookup-miss
   error and beta.1/beta.2 still produced it; the entry below is corrected

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -278,7 +278,9 @@ stale — while `None` means `frame` holds no data at all, so retrying
 achieves nothing until someone inserts into it (see runtime behavior change
 5). Both `requested` and `covered` are in the registry's own time type `T`,
 not in seconds: compare them against the timestamp you asked with. The
-`Display` text still renders seconds.
+`Display` text still renders seconds. The terminating "latest available"
+retry loop — lower the request onto `covered`'s end, never raise it — is
+documented on `RegistryError::NotFoundAt` in the crate docs.
 
 `add_transform`'s rejections are variants of the same enum:
 `RegistryError::NonUnitRotation(norm)`, `NonFiniteValues`,

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,16 +4,27 @@ Every break below was reproduced by compiling the 1.4.1-documented usage
 against 2.0. Work through the compile errors first; then read the runtime
 changes — code that compiles cleanly can still behave differently.
 
-## Coming from a 2.0.0 beta
+## Coming from a 2.0.0 pre-release
 
-2.0.0-beta.4 is the only published 2.x release, so if you are already on 2.x,
-you are on that one. rc.2 deliberately broke the beta-series API freeze to
-close the last one-way doors before stable, and the `2.0.0-rc.2` section of
-[CHANGELOG.md](CHANGELOG.md) is the whole delta from beta.4. Most of the 1.x
+Five 2.x pre-releases were published — 2.0.0-alpha.1 and beta.1 through
+beta.4 — and no release candidate was: on crates.io, 2.0.0 follows beta.4
+directly. 2.0.0 deliberately broke the beta-series API freeze to close the
+last one-way doors before stable; this section lists what that changed,
+from the beta.4 baseline, and the `[2.0.0]` section of
+[CHANGELOG.md](CHANGELOG.md) carries the full record. This guide's section
+carries the earlier pre-releases too: what changed between them sits
+inside API this migration rewrites anyway — the lookup-error variants
+beta.3 reworked (break 3), the `Buffer` type the betas extended, private
+now (break 5) — except one behavior fix, `get_transform_at`'s
+coinciding-frame legs, covered in runtime change 3. The per-pre-release
+history stays readable in the [changelog as published with
+beta.4](https://github.com/deniz-hofmeister/transforms/blob/v2.0.0-beta.4/CHANGELOG.md)
+(one beta.3 entry there mislabels the removed `NotFound` variant
+"never-produced"; it was 1.x's primary lookup-miss error). Most of the 1.x
 breaks below apply to you unchanged — beta.4 still had 1.x's public
 `Transform` fields, public modules and `u128` stamp — so this section only
-lists what is beta.4-specific and points at the numbered break where the fix
-is written out.
+lists what is beta.4-specific and points at the numbered break where the
+fix is written out.
 
 What stops compiling since beta.4:
 
@@ -75,6 +86,13 @@ Silent behavior changes since beta.4 — these compile:
   now keeps `RegistryError<YourClock>` out of a
   `Box<dyn Error + Send + Sync + 'static>`. `Timestamp` and `SystemTime` are
   unaffected.
+- **A frame drained by the wipe stays registered.** beta.4's
+  `delete_transforms_before` dropped a frame left without transforms —
+  the next insert under that child frame could re-parent it or change
+  its kind, and a dropped leaf vanished from the tree entirely
+  (`UnknownFrame`). 2.0's `remove_transforms_before` keeps it, parent
+  and static-or-dynamic kind still pinned by its first insert, and
+  lookups report `NotFoundAt` with `covered: None` (runtime change 5).
 
 ## Compile-time breaks
 
@@ -423,7 +441,11 @@ carrier — but gains `#[non_exhaustive]`, so its literal becomes
    `registry.remove_frame(child)` then re-add. Removing a mid-tree frame
    strands its descendants — re-add each one.
 3. **Same-frame lookup returns the identity.** `get_transform(x, x, t)`
-   errored in 1.x; it now returns `Ok(identity)`.
+   errored in 1.x; it now returns `Ok(identity)`. The same goes for
+   `get_transform_at`'s coinciding-frame legs — `source` equal to the
+   fixed frame, or all three frames equal — which failed with
+   `SameFrameMultiplication` in 1.x (and still in 2.0.0-alpha.1; resolved
+   since beta.1).
 4. **Results always carry the requested timestamp**, including over
    all-static chains.
 5. **Cleanup preserves static transforms — and frame pins.**
@@ -435,7 +457,10 @@ carrier — but gains `#[non_exhaustive]`, so its literal becomes
    `NotFoundAt` — with `covered: None`, not a covered range — rather than
    `UnknownFrame`. `remove_frame` is the only
    release — call it when a frame retires, or the frame map grows without
-   bound.
+   bound. The wipe also resets each frame's `max_age` expiry reference,
+   so a stream restarted at earlier times — a replay, a clock reset —
+   stores again; in 1.x the wiped buffer kept its pre-wipe latest
+   timestamp and silently evicted the restarted stream's first insert.
 6. **No extrapolation anywhere.** An out-of-range lookup fails with
    `RegistryError::NotFoundAt` carrying the frame's covered range, and
    `Transform::interpolate` with `TransformError::TimestampOutOfRange`;

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,6 +45,8 @@ What stops compiling since beta.4:
 - `Quaternion` keeps only its rotation algebra: `+`, `-`, `/` (with
   `QuaternionError::DivisionByZero`), `scale`, `norm_squared` and the
   `Default` impl are removed (break 8).
+- `Vector3` loses `dot`, `cross` and `unit_x`/`unit_y`/`unit_z`
+  (break 9).
 - `Buffer` and the `core` module are private, and so are the leaf modules
   (`geometry::transform`, `time::timestamp`, ...) that beta.4 still exposed
   (break 5).
@@ -461,6 +463,30 @@ norm, by ulps for a freshly normalized rotation and by up to about
 `2e-6` for one at the edge of `UNIT_NORM_TOLERANCE` — so the conjugate
 spelling is the more accurate of the two, not merely the surviving one.
 The components stay public, so anything else is a one-liner.
+
+### 9. `Vector3` sheds `dot`, `cross` and the unit constructors
+
+```rust
+// 1.x
+let d = a.dot(b);
+let c = a.cross(b);
+let x = Vector3::unit_x();
+
+// 2.0
+let d = a.x * b.x + a.y * b.y + a.z * b.z;
+let c = Vector3::new(
+    a.y * b.z - a.z * b.y,
+    a.z * b.x - a.x * b.z,
+    a.x * b.y - a.y * b.x,
+);
+let x = Vector3::new(1.0, 0.0, 0.0);
+```
+
+`dot` and `cross` had no caller outside their own unit tests, the unit
+constructors none at all, and the crate already points more general
+needs at a linear-algebra library. The operator set stays complete —
+`+`, `-`, both scalar multiplications and `/` — and the components stay
+public, so the formulas above are the whole migration.
 
 ## Runtime behavior changes (compile clean, behave differently)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -42,6 +42,9 @@ What stops compiling since beta.4:
 - `Quaternion::new(w, x, y, z)` is renamed
   `Quaternion::from_wxyz(w, x, y, z)` — same order and behavior, a name that
   states that order at the call site.
+- `Quaternion` keeps only its rotation algebra: `+`, `-`, `/` (with
+  `QuaternionError::DivisionByZero`), `scale`, `norm_squared` and the
+  `Default` impl are removed (break 8).
 - `Buffer` and the `core` module are private, and so are the leaf modules
   (`geometry::transform`, `time::timestamp`, ...) that beta.4 still exposed
   (break 5).
@@ -423,6 +426,41 @@ a base for the field assignment that no longer compiles.
 carrier — but gains `#[non_exhaustive]`, so its literal becomes
 `Point::new(position, orientation, timestamp, frame)`. `Vector3` and
 `Quaternion` literals are untouched.
+
+### 8. `Quaternion` is a rotation, not a vector
+
+```rust
+// 1.x
+let blend = (q1.scale(0.75) + q2.scale(0.25)).normalize()?;
+let step = (q2 / q1)?;
+let n2 = q.norm_squared();
+let q0 = Quaternion::default();
+
+// 2.0
+let blend = q1.slerp(q2, 0.25); // blending is slerp's job now
+let step = q2 * q1.conjugate(); // a unit quaternion's inverse is its conjugate
+let n2 = q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z;
+let q0 = Quaternion::identity();
+```
+
+The public surface is the rotation algebra — `*` composes, `conjugate`
+inverts a unit quaternion, `normalize`/`norm` police the unit invariant,
+`rotate_vector` applies, `slerp` interpolates — and nothing else. The
+vector-space operators `+`, `-` and `/`, `scale`, `norm_squared` and the
+`Default` impl leave the public surface: `+`, `-`, `/` and `Default` had
+no caller outside their own unit tests, `norm_squared` served only the
+removed `/`, and `scale` survives privately inside `normalize` and
+`slerp`. Summing rotations and renormalizing is the classic silent wrong
+answer, and `/` compounded it: a NaN divisor returned `Ok` with all-NaN
+components, and an overflowing one returned `Ok` with an all-zero — and
+finite — quaternion, plausible enough to pass an `is_finite` check.
+`QuaternionError::DivisionByZero` is gone with it. For a unit divisor,
+`q2 / q1` computed `q2 * q1.conjugate()` scaled by `1/norm²` — a factor
+that is 1 mathematically but drifts in floating point with the divisor's
+norm, by ulps for a freshly normalized rotation and by up to about
+`2e-6` for one at the edge of `UNIT_NORM_TOLERANCE` — so the conjugate
+spelling is the more accurate of the two, not merely the surviving one.
+The components stay public, so anything else is a one-liner.
 
 ## Runtime behavior changes (compile clean, behave differently)
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ where
 }
 ```
 
-The `Localized` trait provides frame and timestamp introspection, while `Transformable` handles applying transforms. They are separate so that pure geometry types can implement `Transformable` without needing frame/timestamp metadata. The library provides a `Point` type as a reference implementation of both traits.
+The `Localized` trait provides frame and timestamp introspection, while `Transformable` handles applying transforms. They are separate so that pure geometry types can implement `Transformable` without needing frame/timestamp metadata. The library provides a `Point` type as a reference implementation of both traits, and the `Transformable` docs state the exact map an implementation owes: rotate, then translate, with the transform's rotation on the left of the orientation composition.
 
 ## Usage Examples
 

--- a/src/core/registry/error.rs
+++ b/src/core/registry/error.rs
@@ -125,6 +125,77 @@ where
     /// when a data gap and a topological disconnection coexist, the recorded
     /// walk failure takes precedence over the [`Disconnected`](Self::Disconnected)
     /// diagnosis.
+    ///
+    /// The `Some` case supports a terminating "latest available" idiom:
+    /// when `covered`'s end is older than the request, re-ask at that
+    /// end; otherwise stop. Each retry strictly lowers the request onto
+    /// a boundary some frame actually holds, so the loop always ends —
+    /// chasing `covered` without the guard does not: two hops with
+    /// disjoint ranges bounce the request between them forever. When the
+    /// frames this variant reports lie on the target ← source chain —
+    /// always the case when the target is the tree's root, the
+    /// documented map-ward direction, where a source in a different tree
+    /// can only error, never answer — the loop lands on the newest
+    /// instant at or before the initial request that the whole chain
+    /// serves, or errors when there is none. With a mid-tree target the
+    /// walks also visit — and can report — edges above the two frames'
+    /// common ancestor, edges the answer does not use, and the loop
+    /// turns conservative: any transform it returns is genuinely served
+    /// data, but it can land earlier than the newest servable instant,
+    /// and its error is not proof that none exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use transforms::{
+    ///     Registry,
+    ///     errors::RegistryError,
+    ///     geometry::{Quaternion, Transform, Vector3},
+    ///     time::{Stamp, Timestamp},
+    /// };
+    ///
+    /// let mut registry = Registry::new();
+    /// for (parent, child, nanos) in [
+    ///     ("map", "odom", 4_000),
+    ///     ("map", "odom", 9_000),
+    ///     ("odom", "base", 3_000),
+    ///     ("odom", "base", 7_000), // this hop lags: nothing newer yet
+    /// ] {
+    ///     registry
+    ///         .add_transform(
+    ///             Transform::new(
+    ///                 parent,
+    ///                 child,
+    ///                 Vector3::new(1.0, 0.0, 0.0),
+    ///                 Quaternion::identity(),
+    ///                 Stamp::At(Timestamp::from_nanos(nanos)),
+    ///             )
+    ///             .unwrap(),
+    ///         )
+    ///         .unwrap();
+    /// }
+    ///
+    /// // The newest instant the whole map ← base chain can serve; the
+    /// // target is the tree's root, so the loop is exact here.
+    /// let mut requested = Timestamp::from_nanos(10_000); // "now"
+    /// let latest = loop {
+    ///     match registry.get_transform("map", "base", requested) {
+    ///         Ok(transform) => break Ok(transform),
+    ///         Err(RegistryError::NotFoundAt {
+    ///             covered: Some((_, end)),
+    ///             ..
+    ///         }) if end < requested => requested = end,
+    ///         // Nothing at or before the request — or a different fault
+    ///         // entirely (unknown frame, disconnected trees): match on it.
+    ///         Err(error) => break Err(error),
+    ///     }
+    /// };
+    ///
+    /// assert_eq!(
+    ///     latest.unwrap().timestamp(),
+    ///     Stamp::At(Timestamp::from_nanos(7_000))
+    /// );
+    /// ```
     #[error(
         "transform from {source_frame} into {target_frame} at {} not found ({frame} {})",
         .requested.as_seconds_lossy(),

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -309,7 +309,13 @@ where
     /// data the request falls outside of, or `None` — no range to carry —
     /// when it holds no data at all, the state a frame drained by
     /// [`Registry::remove_transforms_before`] stays in until something is
-    /// inserted into it again.
+    /// inserted into it again. "The newest instant this chain can serve
+    /// at or before this request" is answered by retrying off `covered`
+    /// with the guard documented on
+    /// [`RegistryError::NotFoundAt`](crate::errors::RegistryError::NotFoundAt):
+    /// lower the request onto the covered end, never raise it — exact
+    /// when the target is the tree's root, conservative for a mid-tree
+    /// target.
     ///
     /// Composing, inverting or interpolating the transforms the walk
     /// collected can itself fail: inverting a half-chain that composed to an

--- a/src/geometry/point/tests.rs
+++ b/src/geometry/point/tests.rs
@@ -23,13 +23,14 @@ mod point_tests {
     }
 
     #[test]
-    fn transform_rotates_orientation() {
+    fn transform_composes_orientation_on_the_left() {
         let theta = core::f64::consts::PI / 2.0;
         let rot_z_90 = Quaternion::from_wxyz((theta / 2.0).cos(), 0.0, 0.0, (theta / 2.0).sin());
+        let rot_x_90 = Quaternion::from_wxyz((theta / 2.0).cos(), (theta / 2.0).sin(), 0.0, 0.0);
 
         let mut point = Point::new(
             Vector3::new(1.0, 0.0, 0.0),
-            Quaternion::identity(),
+            rot_x_90,
             Timestamp::zero(),
             "b",
         );
@@ -45,11 +46,13 @@ mod point_tests {
 
         point.transform(&transform).unwrap();
 
-        // The orientation must be rotated (quaternion product), not merely
-        // combined component-wise.
+        // Hand-derived rot_z_90 * rot_x_90, written as digits so a flipped
+        // operand order cannot re-derive the expectation from itself: the
+        // starting orientation does not commute with the transform's
+        // rotation, and the flipped product is (0.5, 0.5, -0.5, 0.5).
         let expected = Point::new(
             Vector3::new(0.0, 1.0, 0.0),
-            rot_z_90,
+            Quaternion::from_wxyz(0.5, 0.5, 0.5, 0.5),
             Timestamp::zero(),
             "a",
         );

--- a/src/geometry/quaternion/error.rs
+++ b/src/geometry/quaternion/error.rs
@@ -4,9 +4,6 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum QuaternionError {
-    /// The divisor quaternion has (near-)zero norm.
-    #[error("division by zero quaternion")]
-    DivisionByZero,
     /// The quaternion has (near-)zero norm and cannot be normalized.
     #[error("cannot normalize a zero-length quaternion")]
     ZeroLengthNormalization,

--- a/src/geometry/quaternion/mod.rs
+++ b/src/geometry/quaternion/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::geometry::Vector3;
 use approx::{AbsDiffEq, RelativeEq};
-use core::ops::{Add, Div, Mul, Sub};
+use core::ops::Mul;
 pub use error::QuaternionError;
 
 mod error;
@@ -26,13 +26,6 @@ pub struct Quaternion {
     pub y: f64,
     /// The `z` component of the vector part.
     pub z: f64,
-}
-
-impl Default for Quaternion {
-    /// Returns the identity quaternion.
-    fn default() -> Self {
-        Self::identity()
-    }
 }
 
 impl Quaternion {
@@ -180,39 +173,13 @@ impl Quaternion {
         libm::sqrt(self.w * self.w + self.x * self.x + self.y * self.y + self.z * self.z)
     }
 
-    /// Computes the squared norm of the quaternion.
+    /// Scales every component by `factor`.
     ///
-    /// This is the sum of the squares of the components.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use transforms::geometry::Quaternion;
-    ///
-    /// let q = Quaternion::from_wxyz(1.0, 2.0, 2.0, 2.0);
-    /// assert_eq!(q.norm_squared(), 13.0);
-    /// ```
+    /// Private: scaling a rotation denormalizes it, so the public surface
+    /// does not offer it. `normalize` and `slerp` use it internally.
     #[must_use = "this returns the result of the operation, without modifying the original"]
     #[inline]
-    pub fn norm_squared(self) -> f64 {
-        self.w * self.w + self.x * self.x + self.y * self.y + self.z * self.z
-    }
-
-    /// Scales the quaternion by a given factor.
-    ///
-    /// Multiplies each component of the quaternion by the factor.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use transforms::geometry::Quaternion;
-    ///
-    /// let q = Quaternion::from_wxyz(1.0, 2.0, 3.0, 4.0);
-    /// assert_eq!(q.scale(2.0), Quaternion::from_wxyz(2.0, 4.0, 6.0, 8.0));
-    /// ```
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[inline]
-    pub fn scale(
+    fn scale(
         self,
         factor: f64,
     ) -> Quaternion {
@@ -221,6 +188,27 @@ impl Quaternion {
             x: self.x * factor,
             y: self.y * factor,
             z: self.z * factor,
+        }
+    }
+
+    /// The blend `a * wa + b * wb`, computed component-wise.
+    ///
+    /// Both slerp branches build their result from this sum. Private for
+    /// the same reason `+` is not on the public surface: quaternion
+    /// addition composes no rotation.
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    fn weighted_sum(
+        a: Quaternion,
+        wa: f64,
+        b: Quaternion,
+        wb: f64,
+    ) -> Quaternion {
+        Quaternion {
+            w: a.w * wa + b.w * wb,
+            x: a.x * wa + b.x * wb,
+            y: a.y * wa + b.y * wb,
+            z: a.z * wa + b.z * wb,
         }
     }
 
@@ -309,7 +297,7 @@ impl Quaternion {
         let dot = dot.clamp(-1.0, 1.0);
 
         if dot > 1.0 - f64::EPSILON {
-            let blended = self.scale(1.0 - t) + other.scale(t);
+            let blended = Self::weighted_sum(self, 1.0 - t, other, t);
             let norm = blended.norm();
             return if norm < f64::EPSILON {
                 blended
@@ -324,41 +312,7 @@ impl Quaternion {
         let scale_self = libm::sin((1.0 - t) * theta) / sin_theta;
         let scale_other = libm::sin(t * theta) / sin_theta;
 
-        self.scale(scale_self) + other.scale(scale_other)
-    }
-}
-
-impl Add for Quaternion {
-    type Output = Quaternion;
-
-    #[inline]
-    fn add(
-        self,
-        other: Quaternion,
-    ) -> Quaternion {
-        Quaternion {
-            w: self.w + other.w,
-            x: self.x + other.x,
-            y: self.y + other.y,
-            z: self.z + other.z,
-        }
-    }
-}
-
-impl Sub for Quaternion {
-    type Output = Quaternion;
-
-    #[inline]
-    fn sub(
-        self,
-        other: Quaternion,
-    ) -> Quaternion {
-        Quaternion {
-            w: self.w - other.w,
-            x: self.x - other.x,
-            y: self.y - other.y,
-            z: self.z - other.z,
-        }
+        Self::weighted_sum(self, scale_self, other, scale_other)
     }
 }
 
@@ -376,29 +330,6 @@ impl Mul for Quaternion {
             y: self.w * other.y - self.x * other.z + self.y * other.w + self.z * other.x,
             z: self.w * other.z + self.x * other.y - self.y * other.x + self.z * other.w,
         }
-    }
-}
-
-impl Div for Quaternion {
-    type Output = Result<Quaternion, QuaternionError>;
-
-    /// Divides by `other` via multiplication with its inverse.
-    ///
-    /// Returns `QuaternionError::DivisionByZero` if `other`'s squared norm
-    /// is below `f64::EPSILON`: divisors with a norm under roughly `1.5e-8`
-    /// are rejected as numerically zero — a deliberately stricter threshold
-    /// than [`Quaternion::normalize`]'s, since dividing by a near-zero
-    /// quaternion amplifies error quadratically.
-    #[inline]
-    fn div(
-        self,
-        other: Quaternion,
-    ) -> Result<Quaternion, QuaternionError> {
-        let norm_sq = other.norm_squared();
-        if norm_sq < f64::EPSILON {
-            return Err(QuaternionError::DivisionByZero);
-        }
-        Ok(self.mul(other.conjugate()).scale(1.0 / norm_sq))
     }
 }
 

--- a/src/geometry/quaternion/tests.rs
+++ b/src/geometry/quaternion/tests.rs
@@ -68,13 +68,6 @@ mod quaternion_tests {
     }
 
     #[test]
-    fn norm_squared() {
-        let q = Quaternion::from_wxyz(1.0, 2.0, 3.0, 4.0);
-        let expected = 1.0_f64 + 4.0 + 9.0 + 16.0;
-        assert_relative_eq!(q.norm_squared(), expected, epsilon = f64::EPSILON);
-    }
-
-    #[test]
     fn scale() {
         let q = Quaternion::from_wxyz(1.0, 2.0, 3.0, 4.0);
         let factor = 2.0;
@@ -140,19 +133,13 @@ mod quaternion_tests {
     }
 
     #[test]
-    fn add() {
+    fn weighted_sum_pairs_each_weight_with_its_operand() {
         let q1 = Quaternion::from_wxyz(1.0, 2.0, 3.0, 4.0);
         let q2 = Quaternion::from_wxyz(5.0, 6.0, 7.0, 8.0);
-        let expected = Quaternion::from_wxyz(6.0, 8.0, 10.0, 12.0);
-        assert_eq!(q1 + q2, expected);
-    }
-
-    #[test]
-    fn sub() {
-        let q1 = Quaternion::from_wxyz(1.0, 2.0, 3.0, 4.0);
-        let q2 = Quaternion::from_wxyz(5.0, 6.0, 7.0, 8.0);
-        let expected = Quaternion::from_wxyz(-4.0, -4.0, -4.0, -4.0);
-        assert_eq!(q1 - q2, expected);
+        // Asymmetric weights: a swapped weight/operand pairing yields
+        // (4.0, 5.0, 6.0, 7.0) and fails, where 0.5/0.5 could not tell.
+        let expected = Quaternion::from_wxyz(2.0, 3.0, 4.0, 5.0);
+        assert_eq!(Quaternion::weighted_sum(q1, 0.75, q2, 0.25), expected);
     }
 
     #[test]
@@ -161,28 +148,6 @@ mod quaternion_tests {
         let q2 = Quaternion::from_wxyz(5.0, 6.0, 7.0, 8.0);
         let expected = Quaternion::from_wxyz(-60.0, 12.0, 30.0, 24.0);
         assert_eq!(q1 * q2, expected);
-    }
-
-    #[test]
-    fn div() {
-        let q1 = Quaternion::from_wxyz(1.0, 2.0, 3.0, 4.0);
-        let q2 = Quaternion::from_wxyz(5.0, 6.0, 7.0, 8.0);
-        let result = q1 / q2;
-        assert!(
-            result.is_ok(),
-            "Division of {q1:?} by {q2:?} failed with error {result:?}"
-        );
-    }
-
-    #[test]
-    fn div_by_zero() {
-        let q1 = Quaternion::from_wxyz(1.0, 2.0, 3.0, 4.0);
-        let q2 = Quaternion::from_wxyz(0.0, 0.0, 0.0, 0.0);
-        let result = q1 / q2;
-        assert!(
-            matches!(result, Err(QuaternionError::DivisionByZero)),
-            "Expected DivisionByZero error for {q1:?} / {q2:?}"
-        );
     }
 
     #[test]
@@ -317,7 +282,9 @@ mod quaternion_tests {
         // The shortcut would land 4e-7 off that geodesic here, five orders
         // of magnitude outside the tolerance above — and invisible to a norm
         // check, because the shortcut normalizes its result too.
-        let blended = (q1.scale(0.75) + q2.scale(0.25)).normalize().unwrap();
+        let blended = Quaternion::weighted_sum(q1, 0.75, q2, 0.25)
+            .normalize()
+            .unwrap();
         assert_abs_diff_eq!(blended.norm(), 1.0, epsilon = 1e-15);
         assert!(
             (blended.z - quarter.z).abs() > 1e-9,

--- a/src/geometry/transform/traits.rs
+++ b/src/geometry/transform/traits.rs
@@ -62,6 +62,26 @@ where
 /// a sensor frame), while the parent frame is typically the more general/global frame
 /// (e.g., map or world frame).
 ///
+/// # Contract
+///
+/// An implementation owes the rigid-body map, in this order: every bound
+/// position `p` becomes
+/// `transform.rotation().rotate_vector(p) + transform.translation()` —
+/// rotate first, then translate — and every orientation `q` becomes
+/// `transform.rotation() * q`, the transform's rotation on the left. A
+/// free vector — a velocity, a surface normal — takes the rotation only,
+/// and owes no translation. Where the object carries them, as
+/// [`Point`](crate::geometry::Point) does, its frame becomes the
+/// transform's parent frame; timestamps are checked, never rewritten.
+/// The reversed variants compile, and each has a blind spot that keeps
+/// weak tests green: translating before rotating agrees with the
+/// contract until a real rotation meets a non-zero translation, and
+/// `q * transform.rotation()` agrees until the object's own orientation
+/// is non-identity and does not commute with the transform's. Beyond the
+/// blind spot both produce a silent wrong answer, never a loud failure.
+/// `Point`'s implementation is the reference, and the suite pins both
+/// orders.
+///
 /// # Precondition
 ///
 /// An implementation applies the transform's geometry as given; it checks
@@ -118,6 +138,10 @@ where
     T: TimePoint,
 {
     /// Applies a transform to this object, modifying it in place.
+    ///
+    /// What "applies" must compute — rotate, then translate; the
+    /// transform's rotation on the left of the orientation composition —
+    /// is pinned by the trait-level Contract section.
     ///
     /// # Errors
     ///

--- a/src/geometry/vector3/mod.rs
+++ b/src/geometry/vector3/mod.rs
@@ -1,4 +1,4 @@
-//! A 3D vector type with basic arithmetic, dot, and cross products.
+//! A 3D vector type with basic arithmetic.
 
 use core::ops::{Add, Div, Mul, Sub};
 
@@ -58,68 +58,6 @@ impl Vector3 {
     #[must_use]
     pub const fn zero() -> Self {
         Self::new(0.0, 0.0, 0.0)
-    }
-
-    /// Returns the unit vector along the x-axis `(1.0, 0.0, 0.0)`.
-    #[must_use]
-    pub const fn unit_x() -> Self {
-        Self::new(1.0, 0.0, 0.0)
-    }
-
-    /// Returns the unit vector along the y-axis `(0.0, 1.0, 0.0)`.
-    #[must_use]
-    pub const fn unit_y() -> Self {
-        Self::new(0.0, 1.0, 0.0)
-    }
-
-    /// Returns the unit vector along the z-axis `(0.0, 0.0, 1.0)`.
-    #[must_use]
-    pub const fn unit_z() -> Self {
-        Self::new(0.0, 0.0, 1.0)
-    }
-
-    /// Computes the dot product of two vectors, the sum of the products of their components.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use transforms::geometry::Vector3;
-    ///
-    /// let a = Vector3::new(1.0, 2.0, 3.0);
-    /// let b = Vector3::new(4.0, 5.0, 6.0);
-    /// assert_eq!(a.dot(b), 32.0);
-    /// ```
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[inline]
-    pub fn dot(
-        self,
-        other: Self,
-    ) -> f64 {
-        self.x * other.x + self.y * other.y + self.z * other.z
-    }
-
-    /// Computes the cross product of two vectors, a vector perpendicular to both operands.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use transforms::geometry::Vector3;
-    ///
-    /// let a = Vector3::new(1.0, 0.0, 0.0);
-    /// let b = Vector3::new(0.0, 1.0, 0.0);
-    /// assert_eq!(a.cross(b), Vector3::new(0.0, 0.0, 1.0));
-    /// ```
-    #[must_use = "this returns the result of the operation, without modifying the original"]
-    #[inline]
-    pub fn cross(
-        self,
-        other: Self,
-    ) -> Self {
-        Self {
-            x: self.y * other.z - self.z * other.y,
-            y: self.z * other.x - self.x * other.z,
-            z: self.x * other.y - self.y * other.x,
-        }
     }
 }
 

--- a/src/geometry/vector3/tests.rs
+++ b/src/geometry/vector3/tests.rs
@@ -1,7 +1,5 @@
 #[cfg(test)]
 mod vector3_tests {
-    use approx::assert_relative_eq;
-
     use crate::geometry::Vector3;
 
     #[test]
@@ -34,21 +32,5 @@ mod vector3_tests {
         let scalar = 2.0;
         let expected = Vector3::new(1.0, 2.0, 3.0);
         assert_eq!(v / scalar, expected);
-    }
-
-    #[test]
-    fn dot_product() {
-        let v1 = Vector3::new(1.0, 2.0, 3.0);
-        let v2 = Vector3::new(4.0, 5.0, 6.0);
-        let expected = 32.0;
-        assert_relative_eq!(v1.dot(v2), expected);
-    }
-
-    #[test]
-    fn cross_product() {
-        let v1 = Vector3::new(1.0, 2.0, 3.0);
-        let v2 = Vector3::new(4.0, 5.0, 6.0);
-        let expected = Vector3::new(-3.0, 6.0, -3.0);
-        assert_eq!(v1.cross(v2), expected);
     }
 }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -49,6 +49,16 @@ fn unit_quaternions() -> impl Strategy<Value = Quaternion> {
         })
 }
 
+/// Denormalizes a rotation by scaling every component: the tolerance tests
+/// need norms deliberately off 1, and the public surface offers no
+/// quaternion scaling — a rotation is not a vector here.
+fn scaled(
+    q: Quaternion,
+    factor: f64,
+) -> Quaternion {
+    Quaternion::from_wxyz(q.w * factor, q.x * factor, q.y * factor, q.z * factor)
+}
+
 /// Nanosecond magnitudes spanning the regimes that behave differently:
 /// small counts, both sides of the 2^53 `f64` accuracy cliff, 2020s
 /// wall-clock nanoseconds (where an `f64` ulp is already ~256 ns), and the
@@ -328,7 +338,7 @@ proptest! {
             "a",
             "b",
             Vector3::zero(),
-            rotation.scale(factor),
+            scaled(rotation, factor),
             Stamp::At(Timestamp::from_nanos(1)),
         );
 
@@ -347,7 +357,7 @@ proptest! {
             "a",
             "b",
             Vector3::zero(),
-            rotation.scale(1.0 + deviation),
+            scaled(rotation, 1.0 + deviation),
             Stamp::At(Timestamp::from_nanos(1)),
         );
 

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -7,7 +7,7 @@ use approx::abs_diff_eq;
 use proptest::prelude::*;
 use transforms::{
     Registry, Transformable,
-    errors::TransformError,
+    errors::{RegistryError, TransformError},
     geometry::{Point, Quaternion, Transform, Vector3},
     time::{Stamp, Timestamp},
 };
@@ -255,6 +255,66 @@ proptest! {
             "composed rotation is not the identity: {:?}",
             composed.rotation(),
         );
+    }
+
+    #[test]
+    fn latest_available_retry_is_exact_for_a_root_target(
+        ranges in proptest::collection::vec((0_u64..1_000_000, 1_u64..1_000_000), 2..=4),
+    ) {
+        // Hop i covers [start, start + span]; the target f0 is the root, so
+        // every frame a failed lookup reports is on the resolved chain and
+        // the retry guard documented on `RegistryError::NotFoundAt` is
+        // exact.
+        let mut registry = Registry::new();
+        for (i, (start, span)) in ranges.iter().enumerate() {
+            for nanos in [*start, start + span] {
+                let transform = Transform::new(
+                    &format!("f{i}"),
+                    &format!("f{}", i + 1),
+                    Vector3::new(1.0, 0.0, 0.0),
+                    Quaternion::identity(),
+                    Stamp::At(Timestamp::from_nanos(nanos)),
+                )
+                .unwrap();
+                registry.add_transform(transform).unwrap();
+            }
+        }
+        let leaf = format!("f{}", ranges.len());
+        let newest_common_end = ranges.iter().map(|(start, span)| start + span).min().unwrap();
+        let latest_common_start = ranges.iter().map(|(start, _)| *start).max().unwrap();
+
+        // Ask beyond every range, then lower the request onto each failing
+        // frame's covered end — never raise it.
+        let mut requested = Timestamp::from_nanos(2_000_001);
+        let mut retries = 0_usize;
+        let outcome = loop {
+            match registry.get_transform("f0", &leaf, requested) {
+                Ok(transform) => break Ok(transform),
+                Err(RegistryError::NotFoundAt {
+                    covered: Some((_, end)),
+                    ..
+                }) if end < requested => {
+                    requested = end;
+                    retries += 1;
+                    prop_assert!(retries <= ranges.len(), "one retry per hop exceeded");
+                }
+                Err(error) => break Err(error),
+            }
+        };
+
+        if latest_common_start <= newest_common_end {
+            // The ranges share instants: the loop must land exactly on the
+            // newest commonly covered one.
+            let transform = outcome.unwrap();
+            prop_assert_eq!(
+                transform.timestamp(),
+                Stamp::At(Timestamp::from_nanos(newest_common_end))
+            );
+        } else {
+            // No instant is covered by every hop: the loop must error, not
+            // fabricate a pose.
+            prop_assert!(outcome.is_err());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Six commits of pre-tag release prep for 2.0.0, in two layers.

## Punch list (docs)

- **MIGRATION.md tells the truth about the pre-releases**: five 2.x
  pre-releases are published (alpha.1, beta.1–beta.4), not one; the
  section now stands alone so the changelog consolidation cannot orphan
  its references, and the beta.4 delta gains two items a completeness
  audit surfaced (the frame-keeping wipe; `get_transform_at`'s
  coinciding-frame legs, filed under the 1.x runtime changes where it is
  actually true).
- **Release checklist reordered**: the 2.0.0 changelog consolidation now
  precedes the tag and publish (`CHANGELOG.md`/`MIGRATION.md` ship inside
  the immutable `.crate`), with the orphaned-cross-reference cleanup,
  `Cargo.lock` regeneration, and the merge-before-tag step written in.
- **`Transformable` states the map an implementation owes** — rotate,
  then translate; the transform's rotation on the left — previously
  readable only in `Point`'s source. The flipped orientation order kept
  the entire suite green (every fixture orientation was the identity); a
  new non-commuting test pins the left composition against hand-derived
  digits, verified red under the flip.
- **`RegistryError::NotFoundAt` documents the terminating
  latest-available retry idiom** — lower the request onto the covered
  end, never raise it — exact for a root target, conservative for a
  mid-tree one (both walk behaviors reproduced against this tree), with
  a runnable example and a property test pinning root-target convergence.

## Surface cut (A′ — cut by kind, not by caller)

- **`Quaternion` keeps only its rotation algebra**: `from_wxyz`,
  `identity`, `*`, `conjugate`, `normalize`, `norm`, `rotate_vector`,
  `slerp`. The vector-space surface (`+`, `-`, `/` with
  `QuaternionError::DivisionByZero`, `scale`, `norm_squared`, `Default`)
  leaves the public API — none had a caller outside its own unit tests,
  `/` returned `Ok` with all-NaN components for a NaN divisor and an
  all-zero finite quaternion for an overflowing one, and public `+`/`-`
  invited summing rotations. Slerp's blend moved to a private helper,
  bit-identical under the existing bit-for-bit pins.
- **`Vector3` drops `dot`, `cross`, `unit_x/y/z`**; its operator
  families stay complete (`+`, `-`, both scalar multiplications, `/`),
  so no family is left asymmetric. Everything removed is a one-liner
  over the public components and re-addable additively.

MIGRATION gains compile-breaks 8 and 9 with the replacements written
out; CHANGELOG carries the Breaking entries; AGENTS.md's constructor
list drops `unit_*`.

## Verification

The full gate (`tests/test_all.sh`) is green on the final tree, and
each layer went through adversarial review (five reviewers on the punch
list, two on the cut); every finding was fixed and re-verified,
including two corrections to this PR's own prose (the removed `Div`'s
overflow behavior, and hedging "exactly `q2 * q1.conjugate()`" to the
honest floating-point claim). One release-process decision remains open
and is deliberately not taken here: whether 2.0.0 follows beta.4
directly on crates.io — the docs in this PR are written for that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
