### PR TITLE
Lower the MSRV to 1.85, the edition 2024 floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # criterion 0.8+ declares rust-version 1.86, above the crate's MSRV of
+      # 1.85 (see Cargo.toml). Do not bump past 0.7 while the MSRV stands.
+      - dependency-name: "criterion"
+        versions: [">= 0.8.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
         with:
-          toolchain: "1.86"
+          toolchain: "1.85"
       - name: Check (std)
         run: cargo check --all-targets
       - name: Check (no_std)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,9 @@ code in the same commit.
 The gate below machine-checks lints, formatting, and docs; everything else in
 this section is convention, enforced in review — follow it anyway.
 
-- Edition 2024, `rust-version = "1.86"` (verified by a CI job). `#![warn(missing_docs)]` and
+- Edition 2024, `rust-version = "1.85"` — the edition floor, verified by a
+  CI job; criterion is held at 0.7 to keep it true (see Cargo.toml and the
+  dependabot ignore rule). `#![warn(missing_docs)]` and
   `#![warn(clippy::pedantic)]` must stay at **zero warnings** in both feature
   modes. Never add a new `#[allow]` to get green; fix the cause or ask. The
   standing allowances are `clippy::similar_names` in tests (where `t_a_b`-style
@@ -343,7 +345,7 @@ single source of truth for what the gate is — extend the script, not the
 workflow.
 CI additionally runs the test suite natively on ARM64 as well as x86_64
 (the Raspberry Pi / Jetson deployment class), checks the MSRV
-(`cargo check` on Rust 1.86), and runs `cargo audit` against the RustSec
+(`cargo check` on Rust 1.85), and runs `cargo audit` against the RustSec
 advisory database.
 
 Docs are part of the change: the README (API Reference, What's New, examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- MSRV lowered from 1.86 to 1.85 — the edition 2024 floor, and the rustc
+  Debian 13 "trixie" ships. Every runtime dependency already permits 1.85;
+  the previous 1.86 came solely from the `criterion` dev-dependency, which
+  is held at 0.7 (declared MSRV 1.80) so the claim stays verifiable by the
+  CI MSRV job rather than resting on criterion 0.8's rolling MSRV policy.
+  Dev-only: downstream builds compile the same code as before.
+
 ## [2.1.0] - 2026-08-27
 
 ### Added
@@ -504,6 +515,7 @@ beta.4](https://github.com/deniz-hofmeister/transforms/blob/v2.0.0-beta.4/CHANGE
 - First stable release: `no_std` support, transform chaining, SLERP
   interpolation, `Transformable` trait, automatic buffer cleanup.
 
+[Unreleased]: https://github.com/deniz-hofmeister/transforms/compare/v2.1.0...HEAD
 [2.1.0]: https://github.com/deniz-hofmeister/transforms/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/deniz-hofmeister/transforms/compare/v1.4.1...v2.0.0
 [1.4.1]: https://github.com/deniz-hofmeister/transforms/compare/v1.4.0...v1.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,16 +122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "cc"
-version = "1.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,11 +196,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "criterion"
-version = "0.8.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
- "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -228,7 +208,6 @@ dependencies = [
  "itertools",
  "num-traits",
  "oorandom",
- "page_size",
  "rayon",
  "regex",
  "serde",
@@ -239,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
  "itertools",
@@ -371,12 +350,6 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fnv"
@@ -548,16 +521,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -821,12 +784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,22 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,12 +941,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Deniz Hofmeister"]
 license = "MIT"
 version = "2.1.0"
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.85"
 repository = "https://github.com/deniz-hofmeister/transforms"
 documentation = "https://docs.rs/transforms"
 keywords = ["robotics", "transform", "3d", "coordinate"]
@@ -40,10 +40,13 @@ proptest = "1.7.0"
 serde_json = "1.0.140"
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 log = "0.4.27"
+# Held at 0.7: criterion 0.8 declares rust-version 1.86, above this crate's
+# MSRV of 1.85, and its rolling last-three-stables policy can raise that in
+# any 0.8.x patch — dependabot is told to ignore 0.8 (.github/dependabot.yml).
 # Console output only: `plotters` (the HTML report charts) is deliberately
 # off — nobody reads the reports — and `cargo_bench_support` must be named
 # explicitly or `cargo bench` stops working.
-criterion = { version = "0.8.0", default-features = false, features = [
+criterion = { version = "0.7.0", default-features = false, features = [
     "cargo_bench_support",
     "rayon",
 ] }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ transforms = "2.1.0"
 | `std` | Yes | Enables `Timestamp::now()`, its panic-free `Timestamp::try_now()`, and the `SystemTime` time type |
 | `serde` | No | `Serialize`/`Deserialize` for the geometry and time types |
 
-Minimum supported Rust version: 1.86 (checked in CI).
+Minimum supported Rust version: 1.85 (checked in CI) — the edition 2024
+floor, so it cannot go lower without giving up the edition.
 
 Note on `serde`: `Timestamp` is `#[serde(transparent)]`, so it serializes as
 the bare `u64` nanosecond count — an integer every serde format encodes


### PR DESCRIPTION
## Summary

Drops the declared MSRV from 1.86 to **1.85** — the edition 2024 minimum, so this is the floor. The concrete constituency is distro-pinned toolchains: Debian 13 "trixie" ships rustc 1.85.0 for its stable lifetime.

Every runtime dependency already permits 1.85; the 1.86 came solely from the **criterion dev-dependency** (see `d942297`). Criterion 0.8 declares rust-version 1.86 under a rolling last-three-stables policy, so this PR holds it at **0.7** (declared MSRV 1.80) — making the 1.85 claim structurally verifiable by the CI msrv job rather than dependent on criterion 0.8's declared floor staying accidentally loose (0.8.2 does compile on 1.85 today, but any 0.8.x patch may stop). A dependabot ignore rule (`criterion >= 0.8.0`) keeps the hold-back from being silently bumped away; if an open criterion-0.8 dependabot PR exists, close it manually — the rule only stops future ones.

The benches lose nothing they use: the only relevant 0.8 addition was alloca-based memory-layout randomization, and the downgrade removes criterion's `cc`/`alloca`/`page_size`/winapi transitive deps (net −8 packages in the lockfile). The `["cargo_bench_support", "rayon"]` feature line is identical in 0.7.

The README "v2.0.0 highlights" mention of MSRV 1.86 is deliberately untouched — it is a historical claim about what 2.0.0 shipped with, like the changelog history. Dev-only change: downstream builds compile the same code as before.

## Validation

On a real **1.85.1** toolchain, with the committed lockfile:
- CI msrv matrix: `cargo check --all-targets` in all four feature modes, from a clean build (criterion 0.7.0 confirmed compiling in it)
- Full test suite in all four feature modes — zero failures
- `cargo bench -- --test` in std and no_std — all 16 benchmarks pass
- Bare-metal: `thumbv7em-none-eabihf`, `thumbv6m-none-eabi`, `thumbv8m.main-none-eabihf`, each with and without `serde`

Plus:
- Full gate `tests/test_all.sh` on nightly: **GATE PASSED (all steps completed)**
- `rustup run stable cargo clippy --all-targets -- -D warnings` in all four feature modes (CI's arbiter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)