### PR TITLE
Refresh dependency requirements while preserving Rust 1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refresh dependency version requirements to the latest releases compatible
+  with Rust 1.85, matching the existing lockfile. `criterion` remains at
+  0.7.0 because 0.8 requires Rust 1.86; the crate's MSRV stays at 1.85.
 - Document the existing temporal metadata limitation of `get_transform_at`:
   the result stores only the target stamp even when its geometry refers to
   a different source instant. Callers must retain both instants and apply

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,18 @@ std = ["serde?/std"]
 serde = ["dep:serde"]
 
 [dependencies]
-thiserror = { version = "2.0.12", default-features = false }
+thiserror = { version = "2.0.20", default-features = false }
 approx = { version = "0.5.1", default-features = false }
 hashbrown = "0.17.1"
-libm = { version = "0.2.15", default-features = false }
-serde = { version = "1.0.219", default-features = false, features = ["alloc", "derive"], optional = true }
+libm = { version = "0.2.16", default-features = false }
+serde = { version = "1.0.229", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [dev-dependencies]
-env_logger = "0.11.8"
-proptest = "1.7.0"
-serde_json = "1.0.140"
+env_logger = "0.11.11"
+proptest = "1.11.0"
+serde_json = "1.0.151"
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
-log = "0.4.27"
+log = "0.4.34"
 # Held at 0.7: criterion 0.8 declares rust-version 1.86, above this crate's
 # MSRV of 1.85, and its rolling last-three-stables policy can raise that in
 # any 0.8.x patch — dependabot is told to ignore 0.8 (.github/dependabot.yml).
@@ -50,7 +50,7 @@ criterion = { version = "0.7.0", default-features = false, features = [
     "cargo_bench_support",
     "rayon",
 ] }
-tokio = { version = "1.46.1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 [[example]]
 name = "no_std_minimal"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Full version history lives in [CHANGELOG.md](CHANGELOG.md).
 - The existing single-stamp limitation of `get_transform_at` is documented
   below; its representation is unchanged in this patch.
 
+### v2.1.1
+
+- **MSRV lowered to Rust 1.85**, the edition 2024 floor. `criterion` is
+  held at 0.7 to preserve compatibility; downstream builds compile the
+  same code as before.
+
 ### v2.1.0
 
 - **`Registry::latest_common_time`**: "what is the newest instant this

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Full version history lives in [CHANGELOG.md](CHANGELOG.md).
 
 ### v2.1.2 (Unreleased)
 
+- Dependency version requirements now match the latest Rust 1.85-compatible
+  releases in the lockfile; `criterion` remains at 0.7.0 to preserve the MSRV.
 - `latest_common_time` now reports timestamp arithmetic errors when a custom
   clock cannot interpolate at the newest common instant, instead of returning
   an instant the subsequent lookup cannot serve.


### PR DESCRIPTION
Eight dependency requirements in Cargo.toml lagged behind the latest Rust 1.85-compatible releases already recorded in Cargo.lock. Refresh those requirements and document the update in README.md and CHANGELOG.md.

Keep criterion at 0.7.0: the latest 0.8.2 release requires Rust 1.86. The crate MSRV remains 1.85, and Cargo.lock is unchanged. Restore the missing v2.1.1 entry in the README's What's New section, documenting the reduction from Rust 1.86 to 1.85 and the criterion holdback from that release.

Validation:
- Full nightly verification gate: `rustup run nightly tests/test_all.sh` passed, including after the v2.1.1 documentation fix.
- Rust 1.85 `cargo check --locked --all-targets` passed with default features, no default features, serde, and no default features plus serde.
- `git diff --check` passed.
