### PR TITLE
Release v2.1.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
   # done"), run verbatim, so the two cannot drift apart. It is nightly-only
   # by design; the jobs below add what it deliberately leaves to CI — the
   # stable and MSRV toolchains, the ARM64 runner, the RISC-V target, and the
-  # advisory-database audit.
+  # advisory-database audit and published-API compatibility checks.
   gate:
     name: gate
     runs-on: ubuntu-latest
@@ -198,6 +198,27 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - name: Build for ${{ matrix.target }}
         run: cargo build --no-default-features --target ${{ matrix.target }}
+
+  semver:
+    name: semver
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659
+        with:
+          toolchain: stable
+      - name: Install cargo-semver-checks
+        run: cargo install cargo-semver-checks --locked
+      # Without an explicit baseline, the tool uses the latest published
+      # release from crates.io, so the baseline advances after each release.
+      - name: Check API compatibility (std)
+        run: cargo semver-checks check-release --default-features
+      - name: Check API compatibility (no_std)
+        run: cargo semver-checks check-release --only-explicit-features
+      - name: Check API compatibility (std + serde)
+        run: cargo semver-checks check-release --all-features
+      - name: Check API compatibility (no_std + serde)
+        run: cargo semver-checks check-release --only-explicit-features --features serde
 
   security:
     name: security

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,8 +345,9 @@ single source of truth for what the gate is — extend the script, not the
 workflow.
 CI additionally runs the test suite natively on ARM64 as well as x86_64
 (the Raspberry Pi / Jetson deployment class), checks the MSRV
-(`cargo check` on Rust 1.85), and runs `cargo audit` against the RustSec
-advisory database.
+(`cargo check` on Rust 1.85), runs `cargo audit` against the RustSec
+advisory database, and checks API compatibility against the latest published
+release with `cargo-semver-checks` in all four feature combinations.
 
 Docs are part of the change: the README (API Reference, What's New, examples
 table) and rustdoc must be updated in the same commit as the code they
@@ -429,6 +430,5 @@ tagged tree. The checklist, in order:
 - `cargo publish`.
 - Create a GitHub release for the tag (pre-releases marked as such). For
   2.0.0 stable specifically: mark it as latest.
-- After 2.0.0 is published: add a `cargo-semver-checks` CI job so accidental
-  breaking changes are caught against the published baseline. This is
-  deliberately not added pre-release — everything is breaking against 1.4.1.
+- The `semver` CI job checks against the latest published release; its
+  baseline advances automatically after publication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - Unreleased
+## [2.1.2] - 2026-09-12
+
+### Added
+
+- CI checks API compatibility against the latest published release in all
+  four combinations of the `std` and `serde` features.
 
 ### Fixed
 
@@ -544,7 +549,7 @@ beta.4](https://github.com/deniz-hofmeister/transforms/blob/v2.0.0-beta.4/CHANGE
 - First stable release: `no_std` support, transform chaining, SLERP
   interpolation, `Transformable` trait, automatic buffer cleanup.
 
-[2.1.2]: https://github.com/deniz-hofmeister/transforms/compare/v2.1.1...HEAD
+[2.1.2]: https://github.com/deniz-hofmeister/transforms/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/deniz-hofmeister/transforms/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/deniz-hofmeister/transforms/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/deniz-hofmeister/transforms/compare/v1.4.1...v2.0.0

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A fast, middleware-independent coordinate transform library for Rust.
 
 Full version history lives in [CHANGELOG.md](CHANGELOG.md).
 
-### v2.1.2 (Unreleased)
+### v2.1.2
 
 - Dependency version requirements now match the latest Rust 1.85-compatible
   releases in the lockfile; `criterion` remains at 0.7.0 to preserve the MSRV.
@@ -45,6 +45,8 @@ Full version history lives in [CHANGELOG.md](CHANGELOG.md).
   an instant the subsequent lookup cannot serve.
 - Geometry tests now check approximate comparisons' rejection behavior,
   scalar multiplication, and inversion overflow in individual components.
+- CI checks API compatibility against the latest published release in all
+  four combinations of the `std` and `serde` features.
 - The existing single-stamp limitation of `get_transform_at` is documented
   below; its representation is unchanged in this patch.
 


### PR DESCRIPTION
Prepare v2.1.2 for publication from a tagged master commit. Finalize the changelog date and comparison link, remove the README unreleased label, and add the required semver CI job against the latest published crate across all four std/serde combinations.

The manifest, lockfile, and README installation snippets already specify 2.1.2. The patch fixes latest_common_time timestamp arithmetic for custom clocks, documents get_transform_at source-time provenance limits, strengthens regression coverage, and refreshes Rust 1.85-compatible dependency requirements.

Validation:
- API compatibility against published 2.1.1: all four feature combinations pass (223 checks passed per combination).
- cargo publish --dry-run --locked passes; the 36-file package contents were inspected.
- The full nightly tests/test_all.sh gate passes, including all tests, clippy, formatting, rustdoc, examples, benchmarks, and bare-metal builds with and without serde.
- CI also validates stable, MSRV, ARM64, RISC-V, security, and the new published-baseline semver job before merge.
