### PR TITLE
Reduce dynamic history memory and lookup allocations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,9 @@ altitude. To place a proposed capability:
 
 - `Registry` — public entry point; a `HashMap<String, Buffer>` keyed by **child**
   frame name, plus chain resolution between arbitrary frames.
-- `Buffer` — crate-private, one per child frame: a `BTreeMap<T, Transform<T>>`
-  ordered by timestamp, with interpolation between stored samples. Only
+- `Buffer` — crate-private, one per child frame: a `BTreeMap<T, Sample>`
+  holding dynamic geometry, with frames pinned once per buffer and timestamps
+  in map keys; a static buffer holds one transform. Only
   `Registry` reaches it; it is not part of the public API.
 - `geometry` — `Transform` (translation + rotation + timestamp + parent/child
   frames), `Vector3`, `Quaternion`, and `Point` as the reference implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - Unreleased
+
+### Changed
+
+- Store dynamic history as timestamp keys and geometry, with frame names
+  pinned once per buffer. Borrow those names during lookup walks. Public
+  signatures, serde bytes, interpolation arithmetic, validation, removal,
+  and error precedence are preserved. Host measurements show lower sample
+  memory use and fewer lookup allocations; the README replaces obsolete
+  storage figures and unmeasured MCU rate estimates with measured evidence.
+
 ## [2.1.2] - 2026-09-12
 
 ### Added
@@ -549,6 +560,7 @@ beta.4](https://github.com/deniz-hofmeister/transforms/blob/v2.0.0-beta.4/CHANGE
 - First stable release: `no_std` support, transform chaining, SLERP
   interpolation, `Transformable` trait, automatic buffer cleanup.
 
+[2.1.3]: https://github.com/deniz-hofmeister/transforms/compare/v2.1.2...HEAD
 [2.1.2]: https://github.com/deniz-hofmeister/transforms/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/deniz-hofmeister/transforms/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/deniz-hofmeister/transforms/compare/v2.0.0...v2.1.0

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ A fast, middleware-independent coordinate transform library for Rust.
 
 Full version history lives in [CHANGELOG.md](CHANGELOG.md).
 
+### v2.1.3 (Unreleased)
+
+- Dynamic history stores geometry and a timestamp key instead of complete
+  transforms with repeated frame names. Lookup walks borrow pinned names,
+  reducing allocations without changing results, errors, or serialization.
+  Updated host measurements are in [Performance](#performance).
+
 ### v2.1.2
 
 - Dependency version requirements now match the latest Rust 1.85-compatible
@@ -89,11 +96,9 @@ Full version history lives in [CHANGELOG.md](CHANGELOG.md).
 - **Rust-first API cleanup**: exact `==` with tolerant comparison in the
   `approx` traits, `#[non_exhaustive]` errors, private internals, optional
   `serde` support, an enforced panic policy, and MSRV 1.86.
-- **A stated envelope**: `f64` is a commitment — f32 and mixed precision are
-  Non-Goals — and the [Performance](#performance) section publishes what
-  that costs: measured per-operation timings and allocation counts, ~320 B
-  of resident heap per stored sample under short frame names, and the rates
-  and tree depths that do and do not fit an MCU.
+- **A stated embedded scope**: `f64` and `no_std + alloc` remain the
+  commitments. [Performance](#performance) distinguishes measured host
+  resource usage from bare-metal compilation coverage.
 
 `add_transform` is now fallible — the headline migration for 1.x users:
 
@@ -295,7 +300,7 @@ The main interface for managing transforms. It stores `Buffer` instances (one pe
 
 ### Buffer (internal)
 
-Time-indexed storage for transforms between a specific child-parent frame pair, owned by the registry and not reachable from outside the crate. A dynamic buffer uses a `BTreeMap<T, Transform<T>>` for O(log n) lookups with automatic interpolation for timestamps between stored values; a static buffer stores its single transform inline and serves it for any requested time.
+Time-indexed storage for transforms between a specific child-parent frame pair, owned by the registry and not reachable from outside the crate. A dynamic buffer uses a `BTreeMap<T, Sample>` containing only translation and rotation, with frame names pinned once per buffer and timestamps in the map keys, for O(log n) lookups with automatic interpolation; a static buffer stores its single transform inline and serves it for any requested time.
 
 ### Transform
 
@@ -628,69 +633,59 @@ With `std`, `std::time::SystemTime` support is already implemented, so `Registry
 - **Automatic cleanup**: `with_max_age` registries prevent unbounded memory
   growth; eviction pops expired entries from the front of the map,
   O(log n + evicted) per insert
-- **Allocation profile**: a single-hop lookup performs 5 heap allocations
-  toward an ancestor and 6 in the reverse direction (~0.5 KB churn),
-  regardless of buffer size, plus ~2 per additional hop (135 at 64 hops) —
-  frame names are `String`s; insertion into an existing frame does not clone
-  the frame name
-- **All arithmetic is `f64`**: on single-precision-FPU cores (Cortex-M4F,
-  M33) transform math runs through soft-float; only double-precision FPUs
-  (M7-class) execute it in hardware
-- **Identical numbers in both feature modes**: `sqrt`, `sin`, and `acos`
-  come from [libm](https://crates.io/crates/libm) with and without `std`,
-  never from the platform's own math library, so a desktop replay
-  reproduces the target's interpolated rotations bit for bit
+- **Compact dynamic history**: each sample holds 56 B of geometry plus
+  its `T` map key; parent and child names are stored per buffer. Static
+  buffers still store one complete transform.
+- **Allocation profile**: a single-hop lookup performs 3 heap allocations
+  toward an ancestor and 5 in the reverse direction. Four ancestor-ward
+  hops use 9 allocations; 64 hops use 133. These measurements use nonempty,
+  eight-character frame names. Results still own their names.
+- **All arithmetic is `f64`**: hardware acceleration depends on the actual
+  device's double-precision support; compilation for a target does not
+  establish latency on a particular board.
+- **Same arithmetic in both feature modes**: `sqrt`, `sin`, and `acos`
+  come from [libm](https://crates.io/crates/libm) with and without `std`.
+  The tests pin interpolated rotations bit for bit across those feature
+  modes on the test host. This is not a measurement of cross-device replay.
 
 ### Measured cost
 
-On x86-64 (Intel i7-1065G7, release + LTO, counting global allocator),
-against frames holding 1000 dynamic samples each:
+The v2 storage/traversal comparison used x86-64, release builds, and
+Valgrind 3.27.1. Requested heap bytes exclude allocator bookkeeping and
+fragmentation. The fixtures insert samples in timestamp order; these are
+measurements of those fixtures, not universal memory bounds.
 
-| Operation | Time | Allocations |
-|---|---|---|
-| `add_transform`, steady state under `with_max_age` | ~0.4 µs | 2 |
-| `get_transform`, 1 hop, at a stored stamp | ~0.6 µs | 5 |
-| `get_transform`, 1 hop, interpolated | ~0.7 µs | 5 |
-| `get_transform`, 4 hops toward an ancestor, interpolated | ~1.9 µs | 11 |
-| `get_transform` rejecting an unknown frame among 1000 frames | ~9 µs | 3 |
+| Fixture | Before | Compact history |
+|---|---:|---:|
+| 10,000 dynamic samples, 8-character names | 2,556,806 B | 1,220,983 B |
+| 10,000 dynamic samples, 128-character names | 4,957,408 B | 1,221,825 B |
+| 1-hop stored or interpolated ancestor lookup | 5 allocations | 3 allocations |
+| 1-hop reverse lookup | 6 allocations | 5 allocations |
+| 4-hop interpolated ancestor lookup | 11 allocations | 9 allocations |
 
-Resident memory is about **320 B per stored sample while both frame names
-are 32 characters or shorter** — a 120-byte `Transform`, its entry in the
-ordered map, and the two frame-name strings, including allocator block
-granularity. Every sample owns its own copy of both names, so the figure
-rises with them: each name adds another 32 B per sample for every further
-32 characters. A ROS-style pair of 45-character namespaced names therefore
-costs ~64 B more, about **385 B per sample**, and a dynamic edge published
-at 1 kHz under a one-second `max_age` holds ~320 KB under short names but
-~385 KB under that pair. At equal name length 32-bit targets are smaller
-(`Transform` is 96 B there), but the name strings are not — so size an MCU
-heap from the names you actually publish, not from the headline figure.
+Longer names now add a fixed cost per dynamic edge rather than a cost per
+historical sample. The short-name fixture uses about 122 B of requested
+heap per sample, including map storage. Custom timestamp sizes, insertion
+order, map occupancy, allocator overhead, frame count, and transient
+lookup allocations affect actual heap requirements. The comparison and
+reproduction scripts are in
+[the v2 feasibility report](analysis/v2-feasibility/REPORT.md).
 
 ### Supported envelope
 
-The crate commits to `f64` (see [Non-Goals](#non-goals)), so on cores
-without a double-precision FPU every coordinate operation is emulated in
-software. That, together with the per-sample memory above, is what decides
-fitness:
+The crate retains its `f64`, `no_std + alloc` API and the bare-metal build
+matrix: `thumbv7em-none-eabihf`, `thumbv6m-none-eabi`,
+`thumbv8m.main-none-eabihf`, and `riscv32imc-unknown-none-elf`. This verifies
+compilation, including the optional serde path; it does not establish a
+lookup rate, energy cost, or worst-case execution time on those devices.
+No MCU timing measurements accompany this change. The previous estimated
+rate table and its unmeasured ±2× confidence interval have been removed.
 
-| Platform | Workload | Memory for a 1 s window | Basis |
-|---|---|---|---|
-| x86-64 / ARM64 SBC (Raspberry Pi, Jetson) | 1 kHz tick: 6 dynamic edges published and 3 lookups of 3–5 hops, ~11 µs/tick ≈ 1% of one core | ~1.9 MB, against gigabytes | measured |
-| Cortex-M7 (STM32 F7/H7 — hardware `f64`) | between the rows above and below: the one named MCU class that does not pay soft-float | same per-sample figure | neither measured nor estimated |
-| Cortex-M4F / M33 (`f64` in software) | ~100 Hz, mostly-static tree, one or two dynamic edges: single-digit percent of the core | ~64 KB of a 192 KB SRAM | estimated |
-| Cortex-M4F / M33 | 1 kHz over 6 dynamic edges: **does not fit** — RAM runs out before CPU does | ~1.9 MB against 192 KB SRAM | estimated |
-| Cortex-M0+ / RV32IMC (no FPU) | static trees and occasional lookups; one four-hop lookup is estimated above 1 ms | ~32 KB per dynamic edge at 100 Hz | estimated |
-
-The estimated rows come from first principles — the soft-float symbols a
-bare-metal build links, scaled by the x86-64 measurements above — and
-nothing here was executed on target, so treat them as ±2×. The memory
-column is arithmetic on the short-name per-sample figure above, so it
-bounds the 32-bit rows only for frame names that short — namespaced names
-push every row up.
-
-Static transforms cost one sample forever, so publishing fixed mounts with
-`Transform::static_between` is the cheapest way to keep an embedded tree
-inside this envelope; `with_max_age` bounds the rest.
+Size a target heap using its actual allocator, timestamp type, frame
+count, sample rate, and retention window. `with_max_age` limits timestamp
+history, not the number of samples or frames. Static transforms retain one
+sample and survive cleanup. Measure the intended board and workload before
+assigning a real-time budget.
 
 Benchmarks are available in the `benches/` directory. Run with:
 

--- a/analysis/v2-feasibility/REPORT.md
+++ b/analysis/v2-feasibility/REPORT.md
@@ -1,0 +1,205 @@
+# Validated v2 feasibility
+
+Analysis date: 2026-09-12. Baseline: `56482d1` (2.1.2 unreleased).
+Implementation branch: `feature/v2-feasibility`, based on released v2.1.2
+(`71a263c`) for pull request review. This report does not constitute a release.
+
+Release follow-up: fetched `origin/master` at `71a263c` and the `v2.1.2`
+tag after publication. Its library code, manifest, lockfile, tests, examples,
+and benchmarks are identical to the analysis baseline. The retained changes
+also pass patch-level semver checks against `v2.1.2` in all four feature
+combinations (223 checks pass, 31 skip per run). The appropriate next version
+for these changes is **2.1.3**. A minor release is permitted for substantial
+private improvements but is not required by these changes.
+[SemVer specification, clauses 6–7](https://semver.org/spec/v2.0.0.html).
+PR preparation updated the implementation branch to that release base and
+placed its changelog notes under v2.1.3 (Unreleased). The package version
+remains 2.1.2 until release preparation.
+
+**Two implementation changes are validated for v2:** compact dynamic history
+and borrowing pinned names during the existing lookup walk. Their supporting
+tests and documentation are included. No public API, dependency, feature,
+scalar type, or serde representation was added or replaced.
+
+This is a behavioral compatibility assessment as well as an API comparison.
+Cargo classifies public renames, signature changes, and tightened bounds as
+breaking, while private representation changes can be compatible. It also
+notes that runtime compatibility requires judgment beyond compilation. Here,
+explicitly documented v2 numerical behavior and error payloads were treated
+as contracts. [Cargo's SemVer guidance](https://doc.rust-lang.org/cargo/reference/semver.html).
+
+## Fully implemented and verified locally
+
+| Change | Implementation and compatibility boundary |
+|---|---|
+| Compact dynamic samples | `BTreeMap<T, Sample>` stores translation and rotation only. The existing buffer pins supply the frame names; the key supplies the timestamp. Static storage remains one complete transform. Public `Transform<T>` is unchanged. |
+| Shared interpolation arithmetic | A crate-private `Transform::interpolate_to` serves public interpolation and buffer reconstruction. It preserves duration operations, ratio calculation, zero-span behavior, quaternion interpolation, and arithmetic order. No public geometry type was introduced. |
+| Borrow names during traversal | The current walk follows borrowed pinned parents instead of copying names into scratch strings. Early exits, sampling order, error precedence, shared-tail handling, composition order, and inversion count remain unchanged. |
+| Verification and accurate documentation | Nine compatibility tests, a reference-model property test, reproducible differential/measurement clients, and updated README, changelog, rustdoc, and the buffer architecture sentence in AGENTS.md. Obsolete sample-memory figures and unmeasured MCU rate estimates were removed. |
+
+The new reconstruction through `Transform::unvalidated` is justified by the
+validated transform entering `Buffer::insert`: its numeric fields are copied
+unchanged, its frames are checked against permanent pins, and only dynamic
+timestamps become map keys. Validation at insertion remains in place.
+The map, expiry implementation, static storage, and removal semantics remain
+the existing ones. The numerical operation sequence is shared with public
+interpolation rather than duplicated in storage code.
+
+There is no migration required for these changes. They fit a patch release
+under the compatibility checks below; following the publication of 2.1.2,
+that is 2.1.3. Publishing a version remains the maintainer's release decision.
+
+## Implementations tried and excluded
+
+| Experiment | Observed result | Conclusion for this change |
+|---|---|---|
+| Shared topology-first resolver | Implemented ancestry resolution shared by ordinary lookup and `latest_common_time`, followed by sampling only the connecting edges. Two of eight compatibility tests failed. | Excluded: this implementation changes v2 error precedence and the named failing frame. |
+| Normalize constructed rotations and validate every composition | Implemented both changes in a separate tree. Three existing unit tests and one compatibility test failed. | Excluded: accepted rotation components change, and a documented successful overflowing composition/lookup becomes an error. |
+| `VecDeque` history with binary search | Implemented insertion, upsert, neighbor search, expiry, and manual cleanup. Its 278,880-line `Timestamp` trace matched the baseline. Out-of-order insertion into a 60,000-sample history was about 42 times slower than compact `BTreeMap`. | Excluded on measured workload cost. The prototype was not promoted to full gate acceptance. |
+| Defaulted scalar parameter with generic constructors | A standalone language witness compiled before generalization and failed with E0283 afterward, on nightly and Rust 1.85.1. | A default `S = f64` does not by itself preserve inference for calls such as `Vector::zero()`. This was a language experiment, not an f32 implementation of the crate. |
+
+The path counterexamples are concrete:
+
+- Two known disconnected trees, both unavailable at the requested instant:
+  v2 reports `NotFoundAt` from the target walk; the prototype reports
+  `Disconnected`.
+- A target leg reaches a common ancestor whose own parent edge is unavailable,
+  while the source leg is also unavailable: v2 can report that first failure
+  above the common ancestor; the prototype names the source leg instead.
+
+Thus, “private implementation” alone does not establish compatibility. A
+different resolver could preserve those diagnostics, but no such complete
+replacement was validated here. The retained borrowing change avoids this
+semantic change.
+
+The numerical failures also reject the earlier claim that inverse normalization
+is redundant. The existing inverse regression deliberately constructs an
+accepted near-unit rotation and requires normalization on inversion. Removing
+that protection was not implemented.
+
+## Disposition of the other proposed v3 items
+
+These are compatibility findings, not recommendations to implement untested
+alternatives. A proposed replacement and an additional opt-in API are different
+changes: adding an alternative does not remove the old behavior or enforce the
+new invariant throughout v2.
+
+| Proposal | What the evidence establishes |
+|---|---|
+| Replace `Transform` with geometry, sample, resolved, and cross-time types | Replacing existing argument/return types breaks callers. The compatibility test confirms a cross-time result is currently a `Transform`, carries the target stamp, and can be inserted. An additional typed API would leave that existing route available; it was not implemented or approved here. |
+| Guarantee every successful derived transform is numerically valid | Incompatible with the documented v2 contract and failed numerical prototype. A new opt-in type/API was not tested. |
+| Replace `Mul` with `try_compose` | Removing or changing the existing trait implementation breaks callers. Adding another method does not replace `Mul`; no such public addition was tested. |
+| Accept right-hand identity composition | The executable compatibility witness pins the current `SameFrameMultiplication` error. Changing that documented behavior was excluded under this strict assessment; it is not a signature-only decision. |
+| Replace `Point` with `Pose`, split points/vectors/poses, seal and validate `Point` | Renaming the public type or removing mutable public fields breaks existing uses. An alias or additional types would not establish the proposed new invariants on existing `Point` values. Not implemented. |
+| Rename result accessors to target/source; replace positional lookup with named arguments | Replacing existing names or signatures is breaking. Additional names/builders would require their own API decision and testing; none were added. |
+| Change existing `TransformError` timestamp payloads from `f64` to `T` | Changes public field types and downstream error handling. `#[non_exhaustive]` does not make replacement of existing fields compatible. Not implemented. |
+| Replace timestamp operators with checked methods | The typed downstream witness uses the existing `Result`-returning operators. Removing them breaks that code. Additional methods were not implemented; `TimePoint::checked_sub` already exists. |
+| Require retention at construction; change `Default` | Changes the constructor or its documented behavior. The compatibility witness verifies default storage still interpolates across a 30-second gap. An additional explicit unbounded constructor would leave the existing default in place. |
+| Capacity limits, maximum interpolation gaps, and hole-aware latest-common-time queries | Enabling limits for existing constructors changes accepted data/lookups. Opt-in additions need a fully tested coverage and eviction design; no capacity or gap implementation was validated here. |
+| Freshness relative to a caller-supplied time | `latest_common_time` and checked clock arithmetic already support caller-side age decisions. No additional core freshness API was implemented or validated. |
+| Reject dynamic ancestry for the fixed frame | The new witness accepts a constant dynamic reference frame. A static-only ancestry rule would reject that existing use. Physical stationarity is not proven merely by reading the edge kind. |
+| Reject/cascade removal, explicit root persistence, immutable cached depths | The removal and root-attachment witnesses show descendants survive removal, implicit roots can disappear, and an existing root can later acquire a parent. Depth is not immutable. Preserving those semantics with a different internal graph needs additional implementation and tests. |
+| Private frame interning and O(1) frame existence | Not necessary for the validated memory reduction. No complete ID/reference-count design was implemented; this assessment neither recommends it nor declares it incompatible with v2. |
+| Public frame handles, borrowed results, and zero-allocation lookups | No such API was implemented. Changing the existing owned return type or adding a borrow from the registry changes how callers can retain results across mutation. The measured improvement here is fewer allocations, not zero. |
+| Full f32/f64 parity | No scalar-generic library was implemented. The inference counterexample defeats the proposed default-parameter shortcut as a blanket compatibility argument. Separate opt-in designs remain unverified; the f32 Non-Goal was not changed. |
+| Hardware latency/energy bounds and universal host/MCU replay claims | No hardware measurements were made. The existing embedded build matrix was retained and exercised; no timing or replay guarantee was inferred from compilation. |
+| Shorten AGENTS.md and relocate its rationale | Not performed. Only its storage description changed to match the implementation; contributor-policy restructuring was not needed for these v2 changes. |
+
+## Measurements
+
+Host: Intel Core i7-1065G7, x86-64. Library: release profile. Standalone client:
+`rustc -O`. Heap tools: Valgrind 3.27.1 Massif and Memcheck, with safe Rust
+throughout. These fixtures measure requested heap and process allocation
+deltas, not physical MCU SRAM use. Massif's estimated allocator overhead is
+recorded separately in the JSON; actual allocators may differ.
+
+| Fixture | Starting tree | Retained implementation |
+|---|---:|---:|
+| 10,000 sequential dynamic samples, 8-character names | 2,556,806 B | 1,220,983 B |
+| Same, 128-character names | 4,957,408 B | 1,221,825 B |
+| Single-hop ancestor lookup, exact or interpolated | 5 allocations | 3 allocations |
+| Single-hop reverse lookup | 6 allocations | 5 allocations |
+| Four-hop interpolated ancestor lookup | 11 allocations | 9 allocations |
+| 64-hop ancestor lookup | 135 allocations | 133 allocations |
+
+The 10,000-sample requested-heap reduction is approximately 52% for short
+names and 75% for long names. The numeric payload plus default timestamp key
+is 64 B; it is not the total resident cost. Map occupancy, insertion pattern,
+timestamp size, transient allocations, and allocator overhead still matter.
+
+Seven timing repetitions alternated implementation order. For 1,000
+out-of-order inserts into a prefilled 60,000-sample history, median cost was
+about 0.53 microseconds per insert for compact `BTreeMap`, versus 22.30
+microseconds for `VecDeque`. This establishes a substantial regression in
+that tested workload, not a universal crossover point or an MCU estimate.
+The complete timing ranges are in [host-timings.json](host-timings.json).
+
+## Verification performed
+
+- Baseline and retained implementation: full `tests/test_all.sh` gate.
+  This includes four feature combinations, clippy, rustfmt, rustdoc including
+  docs.rs settings, six examples, benchmark smoke runs in both std modes,
+  and the three ARM bare-metal targets with and without serde.
+- Stable 1.98.0 clippy: all targets, all four feature combinations, with
+  warnings denied. Rust 1.85.1 checks: all four feature combinations.
+- Extra `riscv32imc-unknown-none-elf` builds: with and without serde.
+- `cargo-semver-checks` 0.50.0: `--release-type patch` against `56482d1`
+  in all four feature combinations, plus all features against released
+  `v2.1.1`. Each run reported 223 passing checks, 31 skipped, and no required
+  semver update. This does not prove behavior; the tests below cover that.
+- Nine new public compatibility witnesses and a 256-case reference-model
+  property test pass on both the baseline and retained implementation.
+  The model exercises upserts, out-of-order insertion, bounded/unbounded
+  expiry, cleanup, refill, interpolation, and exact error ranges.
+- Identical 278,880-line differential traces for baseline, compact storage
+  alone, the retained implementation, and baseline/retained `no_std` builds.
+  Traces include numeric `to_bits()` values, frames, stamps, error variants,
+  payloads and formatting, static/dynamic conflicts, removal, cross-time
+  queries, and latest-common-time queries. The same deterministic fixture
+  also matched the deque prototype using `Timestamp`.
+- Existing independent SciPy golden vectors, exact slerp expectations, custom
+  clock tests, validation regressions, and frozen serde bytes remain unchanged
+  and pass the gate.
+
+The local gate ran with Nix Rust 1.100.0-nightly. It emits the same pre-existing
+Cargo manifest advisory about explicit `package.readme` as the baseline;
+compiler/clippy/rustdoc checks passed. Native ARM64 execution, physical MCU
+timing, cross-device replay, and allocation-free operation were not verified
+by this work and are not claimed.
+
+## Reproduction and retained evidence
+
+[verification.json](verification.json) records tool versions, source hashes,
+trace hashes, and check summaries. [baseline-measurements.json](baseline-measurements.json)
+and [candidate-measurements.json](candidate-measurements.json) retain the heap
+and allocation measurements.
+
+Use one selected Rust toolchain consistently on PATH. `run.py` explicitly
+passes that compiler to Cargo to avoid mixing a Nix compiler with rustup's
+compiler. From the repository root, with a separate baseline checkout:
+
+```sh
+git worktree add --detach /tmp/transforms-baseline 56482d1
+python3 analysis/v2-feasibility/run.py /tmp/transforms-baseline /tmp/v2-baseline
+python3 analysis/v2-feasibility/run.py . /tmp/v2-candidate
+cmp /tmp/v2-baseline/trace.txt /tmp/v2-candidate/trace.txt
+python3 analysis/v2-feasibility/measure.py /tmp/v2-baseline
+python3 analysis/v2-feasibility/measure.py /tmp/v2-candidate
+python3 analysis/v2-feasibility/bench.py /tmp/v2-baseline /tmp/v2-candidate
+rustup run nightly tests/test_all.sh
+cargo semver-checks check-release --baseline-rev 56482d1 --release-type patch --all-features
+```
+
+Repeat `run.py` with `--no-default-features` to check the no_std trace.
+Copy `tests/v2_compatibility.rs` and `tests/properties.rs` into the baseline
+checkout to execute the added tests against the original library.
+
+Rejected experimental patches are retained as evidence, not active code:
+[path-prototype.patch](path-prototype.patch) and
+[numeric-prototype.patch](numeric-prototype.patch) apply to separate clean
+`56482d1` checkouts. Copy the compatibility tests there and run them to
+reproduce the failures. [deque-prototype.patch](deque-prototype.patch)
+applies to the retained implementation in a separate checkout. Build its
+probe and include that output directory in `bench.py` to compare timings.
+Compile [scalar-default.rs](scalar-default.rs) normally and then with
+`--cfg generic`; only the latter must fail with E0283.

--- a/analysis/v2-feasibility/baseline-measurements.json
+++ b/analysis/v2-feasibility/baseline-measurements.json
@@ -1,0 +1,65 @@
+{
+  "memory": [
+    {
+      "samples": 1000,
+      "name_length": 8,
+      "requested": 257685,
+      "estimated_allocator_overhead": 33555
+    },
+    {
+      "samples": 1000,
+      "name_length": 128,
+      "requested": 498287,
+      "estimated_allocator_overhead": 17513
+    },
+    {
+      "samples": 10000,
+      "name_length": 8,
+      "requested": 2556806,
+      "estimated_allocator_overhead": 333546
+    },
+    {
+      "samples": 10000,
+      "name_length": 128,
+      "requested": 4957408,
+      "estimated_allocator_overhead": 173504
+    }
+  ],
+  "lookups": [
+    {
+      "depth": 1,
+      "direction": "forward",
+      "stamp": "exact",
+      "allocations": 5.0,
+      "allocated_bytes": 512.0
+    },
+    {
+      "depth": 1,
+      "direction": "reverse",
+      "stamp": "exact",
+      "allocations": 6.0,
+      "allocated_bytes": 520.0
+    },
+    {
+      "depth": 1,
+      "direction": "forward",
+      "stamp": "interpolated",
+      "allocations": 5.0,
+      "allocated_bytes": 512.0
+    },
+    {
+      "depth": 4,
+      "direction": "forward",
+      "stamp": "interpolated",
+      "allocations": 11.0,
+      "allocated_bytes": 560.0
+    },
+    {
+      "depth": 64,
+      "direction": "forward",
+      "stamp": "exact",
+      "allocations": 135.0,
+      "allocated_bytes": 15920.0
+    }
+  ]
+}

--- a/analysis/v2-feasibility/bench.py
+++ b/analysis/v2-feasibility/bench.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Alternate two implementations; report host timings without extrapolating to MCUs."""
+import json
+import pathlib
+import statistics
+import subprocess
+import sys
+
+roots = [pathlib.Path(p) for p in sys.argv[1:]]
+cases = [
+    ["insert", "1000", "1000", "ordered"],
+    ["insert", "1000", "1000", "out_of_order"],
+    ["insert", "60000", "1000", "ordered"],
+    ["insert", "60000", "1000", "out_of_order"],
+    ["time_lookup", "100000", "1", "forward", "exact"],
+    ["time_lookup", "100000", "4", "forward", "interpolated"],
+]
+output = []
+for case in cases:
+    readings = {str(root): [] for root in roots}
+    for repetition in range(7):
+        for root in roots if repetition % 2 == 0 else roots[::-1]:
+            elapsed = int(subprocess.check_output([str(root / "probe"), *case], text=True))
+            operations = int(case[2] if case[0] == "insert" else case[1])
+            readings[str(root)].append(elapsed / operations)
+    output.append({"case": case, "nanoseconds_per_operation": {
+        root: {"median": statistics.median(values), "min": min(values), "max": max(values)}
+        for root, values in readings.items()
+    }})
+print(json.dumps(output, indent=2))

--- a/analysis/v2-feasibility/candidate-measurements.json
+++ b/analysis/v2-feasibility/candidate-measurements.json
@@ -1,0 +1,65 @@
+{
+  "memory": [
+    {
+      "samples": 1000,
+      "name_length": 8,
+      "requested": 124134,
+      "estimated_allocator_overhead": 1586
+    },
+    {
+      "samples": 1000,
+      "name_length": 128,
+      "requested": 124976,
+      "estimated_allocator_overhead": 1528
+    },
+    {
+      "samples": 10000,
+      "name_length": 8,
+      "requested": 1220983,
+      "estimated_allocator_overhead": 13545
+    },
+    {
+      "samples": 10000,
+      "name_length": 128,
+      "requested": 1221825,
+      "estimated_allocator_overhead": 13487
+    }
+  ],
+  "lookups": [
+    {
+      "depth": 1,
+      "direction": "forward",
+      "stamp": "exact",
+      "allocations": 3.0,
+      "allocated_bytes": 496.0
+    },
+    {
+      "depth": 1,
+      "direction": "reverse",
+      "stamp": "exact",
+      "allocations": 5.0,
+      "allocated_bytes": 512.0
+    },
+    {
+      "depth": 1,
+      "direction": "forward",
+      "stamp": "interpolated",
+      "allocations": 3.0,
+      "allocated_bytes": 496.0
+    },
+    {
+      "depth": 4,
+      "direction": "forward",
+      "stamp": "interpolated",
+      "allocations": 9.0,
+      "allocated_bytes": 544.0
+    },
+    {
+      "depth": 64,
+      "direction": "forward",
+      "stamp": "exact",
+      "allocations": 133.0,
+      "allocated_bytes": 15904.0
+    }
+  ]
+}

--- a/analysis/v2-feasibility/deque-prototype.patch
+++ b/analysis/v2-feasibility/deque-prototype.patch
@@ -1,0 +1,161 @@
+--- a/src/core/buffer/mod.rs
++++ b/src/core/buffer/mod.rs
+@@ -58,7 +58,7 @@
+     geometry::{Quaternion, Transform, Vector3},
+     time::{Stamp, TimeError, TimePoint, Timestamp},
+ };
+-use alloc::{collections::BTreeMap, string::String};
++use alloc::{collections::VecDeque, string::String};
+ use core::{fmt, time::Duration};
+ pub(crate) use error::{GetError, InsertError};
+ mod error;
+@@ -135,8 +135,9 @@
+                 .field(
+                     "covered",
+                     &data
+-                        .first_key_value()
+-                        .zip(data.last_key_value())
++                        .front()
++                        .map(|(t, s)| (t, s))
++                        .zip(data.back().map(|(t, s)| (t, s)))
+                         .map(|((start, _), (end, _))| (start, end)),
+                 )
+                 .field("latest", latest_timestamp)
+@@ -177,7 +178,7 @@
+     Static(Option<Transform<T>>),
+     /// A time series of samples, keyed by their instant.
+     Dynamic {
+-        data: BTreeMap<T, Sample>,
++        data: VecDeque<(T, Sample)>,
+         latest_timestamp: Option<T>,
+         max_age: Option<Duration>,
+     },
+@@ -197,7 +198,7 @@
+             parent: None,
+             child: None,
+             kind: Kind::Dynamic {
+-                data: BTreeMap::new(),
++                data: VecDeque::new(),
+                 latest_timestamp: None,
+                 max_age: None,
+             },
+@@ -215,7 +216,7 @@
+             parent: None,
+             child: None,
+             kind: Kind::Dynamic {
+-                data: BTreeMap::new(),
++                data: VecDeque::new(),
+                 latest_timestamp: None,
+                 max_age: Some(max_age),
+             },
+@@ -257,7 +258,10 @@
+         match &self.kind {
+             Kind::Static(Some(_)) => Coverage::AllTime,
+             Kind::Static(None) => Coverage::Empty,
+-            Kind::Dynamic { data, .. } => match (data.first_key_value(), data.last_key_value()) {
++            Kind::Dynamic { data, .. } => match (
++                data.front().map(|(t, s)| (t, s)),
++                data.back().map(|(t, s)| (t, s)),
++            ) {
+                 (Some((&start, _)), Some((&end, _))) => Coverage::Range { start, end },
+                 _ => Coverage::Empty,
+             },
+@@ -346,13 +350,17 @@
+                     Some(current_latest) if current_latest > timestamp => current_latest,
+                     _ => timestamp,
+                 });
+-                data.insert(
+-                    timestamp,
+-                    Sample {
+-                        translation: transform.translation(),
+-                        rotation: transform.rotation(),
+-                    },
+-                );
++                let sample = Sample {
++                    translation: transform.translation(),
++                    rotation: transform.rotation(),
++                };
++                let index = data.partition_point(|(at, _)| *at < timestamp);
++                if let Some((at, stored)) = data.get_mut(index).filter(|(at, _)| *at == timestamp) {
++                    *at = timestamp;
++                    *stored = sample;
++                } else {
++                    data.insert(index, (timestamp, sample));
++                }
+                 remove_expired(data, *latest_timestamp, *max_age);
+             }
+             _ => return Err(InsertError::StaticDynamicConflict),
+@@ -418,7 +426,10 @@
+                 .interpolate_to(after.translation, after.rotation, *start, *end, timestamp)
+                 .map_err(GetError::Interpolation)
+             }
+-            _ => match (data.first_key_value(), data.last_key_value()) {
++            _ => match (
++                data.front().map(|(t, s)| (t, s)),
++                data.back().map(|(t, s)| (t, s)),
++            ) {
+                 (Some((first, _)), Some((last, _))) => Err(GetError::OutOfRange {
+                     start: *first,
+                     end: *last,
+@@ -459,7 +470,11 @@
+             return (None, None);
+         };
+
+-        let before = data.range(..=timestamp).next_back();
++        let index = data.partition_point(|(at, _)| at <= timestamp);
++        let before = index
++            .checked_sub(1)
++            .and_then(|i| data.get(i))
++            .map(|(t, s)| (t, s));
+
+         if let Some((t, _)) = before {
+             if t == timestamp {
+@@ -467,7 +482,7 @@
+             }
+         }
+
+-        let after = data.range(timestamp..).next();
++        let after = data.get(index).map(|(t, s)| (t, s));
+         (before, after)
+     }
+
+@@ -491,13 +506,14 @@
+             // the boundary in O(log n); freeing the evicted prefix is
+             // O(evicted) on top — the same O(log n + evicted) as expiry,
+             // each entry freed exactly once.
+-            let kept = data.split_off(&timestamp);
++            let index = data.partition_point(|(at, _)| *at < timestamp);
++            let kept = data.split_off(index);
+             *data = kept;
+             // The expiry reference must not outlive the samples it was
+             // derived from: a stale value would make `max_age` eviction
+             // measure a restarted stream against the wiped one, silently
+             // evicting every new sample on the insert that added it.
+-            *latest_timestamp = data.last_key_value().map(|(&k, _)| k);
++            *latest_timestamp = data.back().map(|(t, s)| (t, s)).map(|(&k, _)| k);
+         }
+     }
+ }
+@@ -513,7 +529,7 @@
+ /// older than the threshold, so skipping the sweep entirely is the correct
+ /// behavior — the `checked_sub` failure is deliberately not an error.
+ fn remove_expired<T>(
+-    data: &mut BTreeMap<T, Sample>,
++    data: &mut VecDeque<(T, Sample)>,
+     latest_timestamp: Option<T>,
+     max_age: Option<Duration>,
+ ) where
+@@ -521,11 +537,11 @@
+ {
+     if let (Some(max_age), Some(latest_timestamp)) = (max_age, latest_timestamp) {
+         if let Ok(threshold) = latest_timestamp.checked_sub(max_age) {
+-            while let Some((&oldest, _)) = data.first_key_value() {
++            while let Some((&oldest, _)) = data.front().map(|(t, s)| (t, s)) {
+                 if oldest >= threshold {
+                     break;
+                 }
+-                data.pop_first();
++                data.pop_front();
+             }
+         }
+     }

--- a/analysis/v2-feasibility/host-timings.json
+++ b/analysis/v2-feasibility/host-timings.json
@@ -1,0 +1,154 @@
+[
+  {
+    "case": [
+      "insert",
+      "1000",
+      "1000",
+      "ordered"
+    ],
+    "nanoseconds_per_operation": {
+      "/tmp/transforms-v2-evidence/baseline": {
+        "median": 254.915,
+        "min": 247.329,
+        "max": 287.778
+      },
+      "/tmp/transforms-v2-evidence/candidate": {
+        "median": 176.523,
+        "min": 160.219,
+        "max": 240.633
+      },
+      "/tmp/transforms-v2-evidence/deque": {
+        "median": 175.956,
+        "min": 159.433,
+        "max": 203.392
+      }
+    }
+  },
+  {
+    "case": [
+      "insert",
+      "1000",
+      "1000",
+      "out_of_order"
+    ],
+    "nanoseconds_per_operation": {
+      "/tmp/transforms-v2-evidence/baseline": {
+        "median": 320.861,
+        "min": 291.245,
+        "max": 403.986
+      },
+      "/tmp/transforms-v2-evidence/candidate": {
+        "median": 239.631,
+        "min": 198.044,
+        "max": 352.189
+      },
+      "/tmp/transforms-v2-evidence/deque": {
+        "median": 397.676,
+        "min": 395.092,
+        "max": 895.002
+      }
+    }
+  },
+  {
+    "case": [
+      "insert",
+      "60000",
+      "1000",
+      "ordered"
+    ],
+    "nanoseconds_per_operation": {
+      "/tmp/transforms-v2-evidence/baseline": {
+        "median": 270.933,
+        "min": 240.52,
+        "max": 303.248
+      },
+      "/tmp/transforms-v2-evidence/candidate": {
+        "median": 189.093,
+        "min": 173.675,
+        "max": 254.405
+      },
+      "/tmp/transforms-v2-evidence/deque": {
+        "median": 163.312,
+        "min": 147.327,
+        "max": 182.411
+      }
+    }
+  },
+  {
+    "case": [
+      "insert",
+      "60000",
+      "1000",
+      "out_of_order"
+    ],
+    "nanoseconds_per_operation": {
+      "/tmp/transforms-v2-evidence/baseline": {
+        "median": 627.727,
+        "min": 547.404,
+        "max": 868.149
+      },
+      "/tmp/transforms-v2-evidence/candidate": {
+        "median": 530.36,
+        "min": 480.883,
+        "max": 623.627
+      },
+      "/tmp/transforms-v2-evidence/deque": {
+        "median": 22296.886,
+        "min": 22054.208,
+        "max": 23469.07
+      }
+    }
+  },
+  {
+    "case": [
+      "time_lookup",
+      "100000",
+      "1",
+      "forward",
+      "exact"
+    ],
+    "nanoseconds_per_operation": {
+      "/tmp/transforms-v2-evidence/baseline": {
+        "median": 179.86653,
+        "min": 168.6228,
+        "max": 196.19733
+      },
+      "/tmp/transforms-v2-evidence/candidate": {
+        "median": 166.0329,
+        "min": 163.09337,
+        "max": 185.42954
+      },
+      "/tmp/transforms-v2-evidence/deque": {
+        "median": 179.69387,
+        "min": 168.85917,
+        "max": 233.04792
+      }
+    }
+  },
+  {
+    "case": [
+      "time_lookup",
+      "100000",
+      "4",
+      "forward",
+      "interpolated"
+    ],
+    "nanoseconds_per_operation": {
+      "/tmp/transforms-v2-evidence/baseline": {
+        "median": 752.92753,
+        "min": 741.72772,
+        "max": 774.3694
+      },
+      "/tmp/transforms-v2-evidence/candidate": {
+        "median": 689.23081,
+        "min": 681.99646,
+        "max": 706.0313
+      },
+      "/tmp/transforms-v2-evidence/deque": {
+        "median": 669.5953,
+        "min": 629.20074,
+        "max": 687.63887
+      }
+    }
+  }
+]

--- a/analysis/v2-feasibility/measure.py
+++ b/analysis/v2-feasibility/measure.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Measure requested heap bytes and allocation deltas with Valgrind, not unsafe Rust."""
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+probe = root / "probe"
+results = {"memory": [], "lookups": []}
+for count in [1000, 10000]:
+    for length in [8, 128]:
+        output = root / f"massif-{count}-{length}.out"
+        command = ["valgrind", "--tool=massif", "--stacks=no", "--time-unit=B", "--detailed-freq=1",
+                   "--max-snapshots=100", f"--massif-out-file={output}", str(probe), "memory", str(count), str(length)]
+        subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        snapshots = output.read_text().split("snapshot=")[1:]
+        peak = next(s for s in snapshots if "heap_tree=peak" in s)
+        requested = int(re.search(r"mem_heap_B=(\d+)", peak)[1])
+        overhead = int(re.search(r"mem_heap_extra_B=(\d+)", peak)[1])
+        results["memory"].append(dict(samples=count, name_length=length, requested=requested, estimated_allocator_overhead=overhead))
+for depth, direction, stamp in [(1, "forward", "exact"), (1, "reverse", "exact"), (1, "forward", "interpolated"), (4, "forward", "interpolated"), (64, "forward", "exact")]:
+    counts = []
+    for iterations in [0, 1000]:
+        log = root / f"alloc-{depth}-{direction}-{stamp}-{iterations}.log"
+        command = ["valgrind", "--tool=memcheck", "--leak-check=no", "--error-exitcode=97", f"--log-file={log}", str(probe), "lookup", str(iterations), str(depth), direction, stamp]
+        subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        match = re.search(r"total heap usage: ([\d,]+) allocs, [\d,]+ frees, ([\d,]+) bytes allocated", log.read_text())
+        counts.append(tuple(int(n.replace(",", "")) for n in match.groups()))
+    # The process copies argv: "1000" occupies three more bytes than "0".
+    # Remove that setup difference from the lookup byte delta.
+    results["lookups"].append(dict(depth=depth, direction=direction, stamp=stamp,
+                                  allocations=(counts[1][0]-counts[0][0])/1000,
+                                  allocated_bytes=(counts[1][1]-counts[0][1]-3)/1000))
+(root / "measurements.json").write_text(json.dumps(results, indent=2) + "\n")
+print(json.dumps(results, indent=2))

--- a/analysis/v2-feasibility/numeric-prototype.patch
+++ b/analysis/v2-feasibility/numeric-prototype.patch
@@ -1,0 +1,29 @@
+diff --git a/src/geometry/transform/mod.rs b/src/geometry/transform/mod.rs
+index b128139..cd4e453 100644
+--- a/src/geometry/transform/mod.rs
++++ b/src/geometry/transform/mod.rs
+@@ -168,7 +168,7 @@ where
+         rotation: Quaternion,
+         timestamp: Stamp<T>,
+     ) -> Result<Self, TransformError> {
+-        let transform = Self::unvalidated(
++        let mut transform = Self::unvalidated(
+             parent.into(),
+             child.into(),
+             translation,
+@@ -176,6 +176,7 @@ where
+             timestamp,
+         );
+         transform.validate()?;
++        transform.rotation = transform.rotation.normalize()?;
+         Ok(transform)
+     }
+
+@@ -578,6 +579,7 @@ where
+
+         let mut result = self.compose_ignoring_time(rhs)?;
+         result.timestamp = timestamp;
++        result.validate()?;
+         Ok(result)
+     }
+ }

--- a/analysis/v2-feasibility/path-prototype.patch
+++ b/analysis/v2-feasibility/path-prototype.patch
@@ -1,0 +1,276 @@
+diff --git a/src/core/registry/mod.rs b/src/core/registry/mod.rs
+index 6a3234c..5975bdc 100644
+--- a/src/core/registry/mod.rs
++++ b/src/core/registry/mod.rs
+@@ -661,32 +661,8 @@ where
+             return Ok(Stamp::Static);
+         }
+
+-        let (target_edges, target_root) = Self::ancestry(target, &self.data);
+-        let (source_edges, source_root) = Self::ancestry(source, &self.data);
+-        if target_root != source_root {
+-            // The walks ended in different trees: an unknown frame, or two
+-            // known but disconnected ones — the same diagnosis order as a
+-            // failed lookup.
+-            for frame in [target, source] {
+-                if !Self::frame_exists(frame, &self.data) {
+-                    return Err(RegistryError::UnknownFrame(frame.into()));
+-                }
+-            }
+-            return Err(RegistryError::Disconnected {
+-                target_frame: target.into(),
+-                source_frame: source.into(),
+-            });
+-        }
+-
+-        // Drop the shared tail above the common ancestor: the connecting
+-        // chain does not cross those edges, so their coverage must not
+-        // constrain the answer.
+-        let shared = target_edges
+-            .iter()
+-            .rev()
+-            .zip(source_edges.iter().rev())
+-            .take_while(|((target_frame, _), (source_frame, _))| target_frame == source_frame)
+-            .count();
++        let (target_edges, source_edges) = Self::connecting_path(target, source, &self.data)?;
++        let shared = 0;
+         let chain = target_edges
+             .iter()
+             .take(target_edges.len() - shared)
+@@ -952,104 +928,72 @@ where
+             ));
+         }
+
+-        let reached = |chain: &VecDeque<Transform<T>>, goal: &str| {
+-            chain.back().is_some_and(|tf| tf.parent() == goal)
+-        };
+-
+-        let mut walk_failure = None;
+-        let target_chain =
+-            Self::get_transform_chain(target, source, timestamp, data, &mut walk_failure);
+-
+-        let result = match target_chain {
+-            // `source` is an ancestor of `target`: the target-side chain
+-            // spans the whole path, no source-side walk is needed.
+-            Some(target_chain) if reached(&target_chain, source) => {
+-                Self::combine_transforms(target_chain, VecDeque::new())
+-            }
+-            target_chain => match (
+-                target_chain,
+-                Self::get_transform_chain(source, target, timestamp, data, &mut walk_failure),
+-            ) {
+-                // `target` is an ancestor of `source`: the source-side chain
+-                // spans the whole path by itself.
+-                (_, Some(source_chain)) if reached(&source_chain, target) => {
+-                    Self::combine_transforms(VecDeque::new(), source_chain)
+-                }
+-                // Both chains ran to the root: drop the shared suffix above
+-                // the common parent and combine the remainders.
+-                (Some(mut target_chain), Some(mut source_chain)) => {
+-                    Self::truncate_at_common_parent(&mut target_chain, &mut source_chain);
+-                    // The two walks must meet at a common parent; otherwise
+-                    // they stopped in different subtrees — an unknown frame,
+-                    // a mid-chain timestamp gap, or disconnected trees — and
+-                    // no transform exists at this time. Diagnose the failure
+-                    // instead of letting the junction fail composition with
+-                    // a misleading IncompatibleFrames.
+-                    let connected = match (target_chain.back(), source_chain.back()) {
+-                        (Some(target_top), Some(source_top)) => {
+-                            target_top.parent() == source_top.parent()
+-                        }
+-                        _ => false,
+-                    };
+-                    if connected {
+-                        Self::combine_transforms(target_chain, source_chain)
+-                    } else {
+-                        Some(Err(Self::diagnose_not_found(
++        let (target_edges, source_edges) = Self::connecting_path(target, source, data)?;
++        let mut target_chain = VecDeque::new();
++        let mut source_chain = VecDeque::new();
++        for (edges, chain) in [
++            (target_edges, &mut target_chain),
++            (source_edges, &mut source_chain),
++        ] {
++            for (frame, buffer) in edges {
++                match buffer.get(timestamp) {
++                    Ok(tf) => chain.push_back(tf),
++                    Err(error) => {
++                        return Err(Self::diagnose_not_found(
+                             target,
+                             source,
+                             timestamp,
+                             data,
+-                            &mut walk_failure,
+-                        )))
++                            &mut Some((frame.into(), error)),
++                        ));
+                     }
+                 }
+-                (Some(target_chain), None) => {
+-                    Self::combine_transforms(target_chain, VecDeque::new())
+-                }
+-                (None, Some(source_chain)) => {
+-                    Self::combine_transforms(VecDeque::new(), source_chain)
+-                }
+-                (None, None) => Some(Err(Self::diagnose_not_found(
+-                    target,
+-                    source,
+-                    timestamp,
+-                    data,
+-                    &mut walk_failure,
+-                ))),
+-            },
++            }
+         }
+-        // Both walks empty without a recorded failure cannot happen today
+-        // (every call site passes at least one non-empty chain), but if it
+-        // ever does, it is a failed lookup and diagnosed as such.
+-        .unwrap_or_else(|| {
+-            Err(Self::diagnose_not_found(
+-                target,
+-                source,
+-                timestamp,
+-                data,
+-                &mut walk_failure,
+-            ))
+-        })?;
++        Self::combine_transforms(target_chain, source_chain)
++            .unwrap_or_else(|| {
++                Err(Self::diagnose_not_found(
++                    target, source, timestamp, data, &mut None,
++                ))
++            })
++            .map(|result| result.restamped(Stamp::At(timestamp)))
++    }
+
+-        // A chain can resolve without ever reaching the requested frame, for
+-        // example when `source` does not exist in the tree and the walk
+-        // stopped at the root instead. Verify the combined transform answers
+-        // the exact question asked; otherwise report it as not found.
+-        if result.parent() != target || result.child() != source {
+-            return Err(Self::diagnose_not_found(
+-                target,
+-                source,
+-                timestamp,
+-                data,
+-                &mut walk_failure,
+-            ));
++    fn connecting_path<'a>(
++        target: &'a str,
++        source: &'a str,
++        data: &'a HashMap<String, Buffer<T>>,
++    ) -> Result<(Vec<(&'a str, &'a Buffer<T>)>, Vec<(&'a str, &'a Buffer<T>)>), RegistryError<T>>
++    {
++        let (mut target_edges, target_root) = Self::ancestry(target, data);
++        let (mut source_edges, source_root) = Self::ancestry(source, data);
++        if target_root != source_root {
++            // The walks ended in different trees: an unknown frame, or two
++            // known but disconnected ones — the same diagnosis order as a
++            // failed lookup.
++            for frame in [target, source] {
++                if !Self::frame_exists(frame, data) {
++                    return Err(RegistryError::UnknownFrame(frame.into()));
++                }
++            }
++            return Err(RegistryError::Disconnected {
++                target_frame: target.into(),
++                source_frame: source.into(),
++            });
+         }
+
+-        // The result answers "where is `source` relative to `target` at the
+-        // requested time", so it carries the requested timestamp — also for
+-        // chains of static transforms, which are themselves stamped
+-        // `Stamp::Static`.
+-        Ok(result.restamped(Stamp::At(timestamp)))
++        // Drop the shared tail above the common ancestor: the connecting
++        // chain does not cross those edges, so their coverage must not
++        // constrain the answer.
++        let shared = target_edges
++            .iter()
++            .rev()
++            .zip(source_edges.iter().rev())
++            .take_while(|((target_frame, _), (source_frame, _))| target_frame == source_frame)
++            .count();
++        target_edges.truncate(target_edges.len() - shared);
++        source_edges.truncate(source_edges.len() - shared);
++        Ok((target_edges, source_edges))
+     }
+
+     /// Retrieves a transform between two frames at different timestamps using a fixed frame.
+@@ -1133,75 +1077,6 @@ where
+         Ok(result.restamped(Stamp::At(target_time)))
+     }
+
+-    /// Constructs a chain of transforms from a starting frame to a target
+-    /// frame at a given timestamp, or `None` if the walk yields no
+-    /// transforms. Diagnosing the reason is the caller's job
+-    /// (`diagnose_not_found`).
+-    ///
+-    /// A buffer lookup failing along the way ends the walk; the first such
+-    /// failure across all walks of one lookup is recorded in `walk_failure`
+-    /// so the caller can report it if the lookup fails as a whole.
+-    fn get_transform_chain(
+-        from: &str,
+-        to: &str,
+-        timestamp: T,
+-        data: &HashMap<String, Buffer<T>>,
+-        walk_failure: &mut Option<(String, GetError<T>)>,
+-    ) -> Option<VecDeque<Transform<T>>> {
+-        let mut transforms = VecDeque::new();
+-        let mut current_frame: String = from.into();
+-
+-        // The frame tree is acyclic by construction (cycles are rejected at
+-        // insertion), so the walk visits every frame at most once and
+-        // terminates at a root.
+-        while let Some(frame_buffer) = data.get(&current_frame) {
+-            match frame_buffer.get(timestamp) {
+-                Ok(tf) => {
+-                    current_frame.clear();
+-                    current_frame.push_str(tf.parent());
+-                    transforms.push_back(tf);
+-                }
+-                Err(source) => {
+-                    if walk_failure.is_none() {
+-                        *walk_failure = Some((current_frame.clone(), source));
+-                    }
+-                    break;
+-                }
+-            }
+-
+-            // Reaching `to` completes the chain; walking on to the root would
+-            // only add work that truncate_at_common_parent discards again.
+-            if current_frame == to {
+-                break;
+-            }
+-        }
+-
+-        if transforms.is_empty() {
+-            None
+-        } else {
+-            Some(transforms)
+-        }
+-    }
+-
+-    /// Truncates two transform chains at their common parent frame to optimize the transformation computation.
+-    fn truncate_at_common_parent(
+-        from_chain: &mut VecDeque<Transform<T>>,
+-        to_chain: &mut VecDeque<Transform<T>>,
+-    ) {
+-        let mut start_idx = 0;
+-        for (i, j) in from_chain.iter().rev().zip(to_chain.iter().rev()) {
+-            if i == j {
+-                start_idx += 1;
+-            } else {
+-                break;
+-            }
+-        }
+-
+-        // Truncate the chains at the common parent frame
+-        from_chain.truncate(from_chain.len() - start_idx);
+-        to_chain.truncate(to_chain.len() - start_idx);
+-    }
+-
+     /// Combines the two half-chains of a lookup into the transform that
+     /// expresses `source` in `target`.
+     ///

--- a/analysis/v2-feasibility/probe.rs
+++ b/analysis/v2-feasibility/probe.rs
@@ -1,0 +1,190 @@
+//! Standalone, safe-Rust differential and heap-measurement client.
+//! Compile against each revision with the accompanying run.py script.
+
+use std::{hint::black_box, time::Duration};
+use transforms::{
+    Registry,
+    errors::RegistryError,
+    geometry::{Quaternion, Transform, Vector3},
+    time::{Stamp, Timestamp},
+};
+
+fn sample(
+    parent: &str,
+    child: &str,
+    nanos: u64,
+    variant: u64,
+    static_edge: bool,
+) -> Transform {
+    let rotations = [
+        Quaternion::identity(),
+        Quaternion::from_wxyz(0.5, 0.5, -0.5, 0.5),
+        Quaternion::from_wxyz(1.0 - 9e-7, 0.0, 0.0, 0.0),
+        Quaternion::from_wxyz(-0.5, 0.5, -0.5, 0.5),
+    ];
+    let translation = match variant % 5 {
+        0 => Vector3::new(-0.0, 2.0, -3.0),
+        1 => Vector3::new(1e308, -1e308, 1e308),
+        _ => Vector3::new(3.125, -0.125, 9.75),
+    };
+    Transform::new(
+        parent,
+        child,
+        translation,
+        rotations[(variant % 4) as usize],
+        if static_edge {
+            Stamp::Static
+        } else {
+            Stamp::At(Timestamp::from_nanos(nanos))
+        },
+    )
+    .unwrap()
+}
+
+fn print_result(result: Result<Transform, RegistryError>) {
+    match result {
+        Ok(t) => {
+            let p = t.translation();
+            let q = t.rotation();
+            let bits = [p.x, p.y, p.z, q.w, q.x, q.y, q.z].map(f64::to_bits);
+            println!(
+                "ok {} {} {:?} {bits:x?}",
+                t.parent(),
+                t.child(),
+                t.timestamp()
+            );
+        }
+        Err(e) => println!("err {e:?} | {e}"),
+    }
+}
+
+fn trace() {
+    let names = ["root", "a", "b", "c", "d", "other", "e", "missing"];
+    let mut random = 0x2a_39_71_85_u64;
+    for retention in [None, Some(Duration::ZERO), Some(Duration::from_nanos(12))] {
+        let mut registry = retention.map_or_else(Registry::new, Registry::with_max_age);
+        for step in 0..800 {
+            random = random.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let child = 1 + (random >> 16) as usize % 6;
+            let parent = (random >> 32) as usize % child;
+            let nanos = (random >> 8) % 32;
+            match random % 10 {
+                0 => println!(
+                    "remove {} {}",
+                    names[child],
+                    registry.remove_frame(names[child])
+                ),
+                1 => {
+                    registry.remove_transforms_before(Timestamp::from_nanos(nanos));
+                    println!("clear {nanos}");
+                }
+                _ => println!(
+                    "insert {:?}",
+                    registry.add_transform(sample(
+                        names[parent],
+                        names[child],
+                        nanos,
+                        random >> 40,
+                        random % 7 == 0
+                    ))
+                ),
+            }
+            if step % 5 == 0 {
+                for target in names {
+                    for source in names {
+                        println!("case {retention:?} {step} {target} {source}");
+                        println!("latest {:?}", registry.latest_common_time(target, source));
+                        for time in [0, 8, 16, 24, 31, 32] {
+                            print_result(registry.get_transform(
+                                target,
+                                source,
+                                Timestamp::from_nanos(time),
+                            ));
+                        }
+                        print_result(registry.get_transform_at(
+                            target,
+                            Timestamp::from_nanos(24),
+                            source,
+                            Timestamp::from_nanos(8),
+                            "root",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn populated(
+    samples: u64,
+    name_length: usize,
+    depth: usize,
+) -> (Registry, Vec<String>) {
+    let names: Vec<_> = (0..=depth).map(|i| format!("{i:0name_length$}")).collect();
+    let mut registry = Registry::new();
+    for edge in names.windows(2) {
+        for time in 0..samples {
+            registry
+                .add_transform(sample(&edge[0], &edge[1], time * 2, 3, false))
+                .unwrap();
+        }
+    }
+    (registry, names)
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    match args[1].as_str() {
+        "trace" => trace(),
+        "memory" => {
+            let (registry, names) =
+                populated(args[2].parse().unwrap(), args[3].parse().unwrap(), 1);
+            black_box((&registry, &names));
+        }
+        "lookup" | "time_lookup" => {
+            let iterations: usize = args[2].parse().unwrap();
+            let depth: usize = args[3].parse().unwrap();
+            let (registry, names) = populated(1000, 8, depth);
+            let (target, source) = if args[4] == "reverse" {
+                (&names[depth], &names[0])
+            } else {
+                (&names[0], &names[depth])
+            };
+            let time = if args[5] == "exact" { 1000 } else { 1001 };
+            let started = std::time::Instant::now();
+            for _ in 0..iterations {
+                black_box(
+                    registry
+                        .get_transform(
+                            black_box(target),
+                            black_box(source),
+                            Timestamp::from_nanos(time),
+                        )
+                        .unwrap(),
+                );
+            }
+            if args[1] == "time_lookup" {
+                println!("{}", started.elapsed().as_nanos());
+            }
+        }
+        "insert" => {
+            let size: u64 = args[2].parse().unwrap();
+            let iterations: u64 = args[3].parse().unwrap();
+            let (mut registry, names) = populated(size, 8, 1);
+            let start = std::time::Instant::now();
+            for i in 0..iterations {
+                let at = if args[4] == "ordered" {
+                    (size + i) * 2
+                } else {
+                    (i * 7919 % size) * 2 + 1
+                };
+                registry
+                    .add_transform(black_box(sample(&names[0], &names[1], at, 3, false)))
+                    .unwrap();
+            }
+            println!("{}", start.elapsed().as_nanos());
+            black_box(registry);
+        }
+        other => panic!("unknown probe {other}"),
+    }
+}

--- a/analysis/v2-feasibility/run.py
+++ b/analysis/v2-feasibility/run.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Build one standalone client against a selected tree; no added dependencies."""
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument("tree", type=pathlib.Path)
+parser.add_argument("output", type=pathlib.Path)
+parser.add_argument("--no-default-features", action="store_true")
+args = parser.parse_args()
+args.output.mkdir(parents=True, exist_ok=True)
+target = args.output.resolve() / "target"
+command = ["rustup", "run", "nightly", "cargo", "build", "--release", "--locked",
+           "--manifest-path", str(args.tree.resolve() / "Cargo.toml"), "--target-dir", str(target)]
+if args.no_default_features:
+    command.append("--no-default-features")
+compiler = [os.environ.get("RUSTC", shutil.which("rustc"))]
+subprocess.run(command, check=True, env={**os.environ, "RUSTC": compiler[0]})
+subprocess.run([*compiler, "--edition=2024", "-O",
+                str(pathlib.Path(__file__).with_name("probe.rs")), "--extern",
+                f"transforms={target / 'release/libtransforms.rlib'}", "-L",
+                f"dependency={target / 'release/deps'}", "-o", str(args.output.resolve() / "probe")], check=True)
+with (args.output / "trace.txt").open("w") as output:
+    subprocess.run([str(args.output.resolve() / "probe"), "trace"], stdout=output, check=True)

--- a/analysis/v2-feasibility/scalar-default.rs
+++ b/analysis/v2-feasibility/scalar-default.rs
@@ -1,0 +1,35 @@
+//! Minimal Rust type-inference witness, not an implementation of f32 transforms.
+
+#[cfg(not(generic))]
+struct Vector(f64);
+
+#[cfg(not(generic))]
+impl Vector {
+    fn zero() -> Self {
+        Self(0.0)
+    }
+}
+
+#[cfg(generic)]
+struct Vector<S = f64>(S);
+
+#[cfg(generic)]
+trait Scalar: Default {}
+
+#[cfg(generic)]
+impl Scalar for f64 {}
+
+#[cfg(generic)]
+impl Scalar for f32 {}
+
+#[cfg(generic)]
+impl<S: Scalar> Vector<S> {
+    fn zero() -> Self {
+        Self(S::default())
+    }
+}
+
+fn main() {
+    let value = Vector::zero();
+    let _ = value.0;
+}

--- a/analysis/v2-feasibility/verification.json
+++ b/analysis/v2-feasibility/verification.json
@@ -1,0 +1,77 @@
+{
+  "baseline_revision": "56482d172925d5ae6477f886a86fbba9376e572c",
+  "branch": "feature/v2-feasibility",
+  "gate": "GATE PASSED (all steps completed)",
+  "toolchains": {
+    "gate_and_probes": "rustc 1.100.0-nightly (0fc141305 2026-09-11)",
+    "stable": "rustc 1.98.0 (88d9e12ae 2026-08-18)",
+    "msrv": "rustc 1.85.1 (4eb161250 2025-03-15)"
+  },
+  "traces": {
+    "baseline": {
+      "lines": 278880,
+      "sha256": "b77b197346248d9b6aacfbfbe495d2c48331e59373f3f2d5563096a81bf438f5"
+    },
+    "compact": {
+      "lines": 278880,
+      "sha256": "b77b197346248d9b6aacfbfbe495d2c48331e59373f3f2d5563096a81bf438f5"
+    },
+    "candidate": {
+      "lines": 278880,
+      "sha256": "b77b197346248d9b6aacfbfbe495d2c48331e59373f3f2d5563096a81bf438f5"
+    },
+    "baseline-no-std": {
+      "lines": 278880,
+      "sha256": "b77b197346248d9b6aacfbfbe495d2c48331e59373f3f2d5563096a81bf438f5"
+    },
+    "candidate-no-std": {
+      "lines": 278880,
+      "sha256": "b77b197346248d9b6aacfbfbe495d2c48331e59373f3f2d5563096a81bf438f5"
+    },
+    "deque": {
+      "lines": 278880,
+      "sha256": "b77b197346248d9b6aacfbfbe495d2c48331e59373f3f2d5563096a81bf438f5"
+    }
+  },
+  "semver_checks": {
+    "std": "223 checks: 223 pass, 31 skip",
+    "no-std": "223 checks: 223 pass, 31 skip",
+    "serde": "223 checks: 223 pass, 31 skip",
+    "no-std-serde": "223 checks: 223 pass, 31 skip",
+    "released": "223 checks: 223 pass, 31 skip"
+  },
+  "msrv_and_stable_clippy": "all four feature combinations passed",
+  "extra_bare_metal": "riscv32imc-unknown-none-elf with and without serde passed",
+  "retained_library_files": {
+    "src/core/buffer/mod.rs": "92db399f5af6d82bc47c2b23c2b3ae118b4b335e0e03571653b9b2acc46a0d11",
+    "src/core/registry/mod.rs": "68acc56bf9243d36d94bb6e25ee2b4b7c27c2ef44f2298941c6b224030584935",
+    "src/geometry/transform/mod.rs": "235403eb9bdc5c1aa9082a9ece231fda49084de2881cb6ba85611cde42a59f4a"
+  },
+  "prototypes": {
+    "path": "6 compatibility tests passed, 2 failed",
+    "numeric": "154 existing unit tests passed, 3 failed; 7 compatibility tests passed, 1 failed",
+    "scalar_default": "concrete compiles, generic E0283 on nightly and Rust 1.85",
+    "deque": {
+      "trace": "matches baseline",
+      "60000_sample_out_of_order_insert_median_ns": {
+        "baseline": 627.727,
+        "candidate": 530.36,
+        "deque": 22296.886
+      }
+    }
+  },
+  "release_followup": {
+    "released_tag": "v2.1.2",
+    "released_commit": "71a263c11c5faa5eb1e80a5c14c1f59ce233b089",
+    "code_identical_to_original_baseline": true,
+    "patch_semver_checks": {
+      "std": "223 checks: 223 pass, 31 skip",
+      "no-std": "223 checks: 223 pass, 31 skip",
+      "serde": "223 checks: 223 pass, 31 skip",
+      "no-std-serde": "223 checks: 223 pass, 31 skip"
+    },
+    "next_patch_version": "2.1.3",
+    "unreleased_changelog_version": "2.1.3"
+  },
+  "pr_base_revision": "71a263c"
+}

--- a/src/core/buffer/mod.rs
+++ b/src/core/buffer/mod.rs
@@ -29,6 +29,11 @@
 //! before a transform starts answering lookups, and the check is O(1) per
 //! insert.
 //!
+//! Dynamic samples retain only translation and rotation: their frames live
+//! in the buffer's pins and their timestamps in the ordered map's keys.
+//! Reads reconstruct the public `Transform` with those same values, using
+//! the same interpolation arithmetic as `Transform::interpolate`.
+//!
 //! # Features
 //!
 //! - **Store Transforms with Timestamps**: The `Buffer` allows you to store multiple transforms,
@@ -55,7 +60,7 @@
 //!     cleanup.
 
 use crate::{
-    geometry::Transform,
+    geometry::{Quaternion, Transform, Vector3},
     time::{Stamp, TimeError, TimePoint, Timestamp},
 };
 use alloc::{collections::BTreeMap, string::String};
@@ -63,10 +68,14 @@ use core::{fmt, time::Duration};
 pub(crate) use error::{GetError, InsertError};
 mod error;
 
-type NearestTransforms<'a, T> = (
-    Option<(&'a T, &'a Transform<T>)>,
-    Option<(&'a T, &'a Transform<T>)>,
-);
+type NearestTransforms<'a, T> = (Option<(&'a T, &'a Sample)>, Option<(&'a T, &'a Sample)>);
+
+/// Geometry copied from a transform validated by `Buffer::insert`. Dynamic
+/// samples share the buffer's pinned frames and use the map key as their stamp.
+struct Sample {
+    translation: Vector3,
+    rotation: Quaternion,
+}
 
 /// A buffer that stores transforms ordered by timestamps.
 ///
@@ -173,7 +182,7 @@ where
     Static(Option<Transform<T>>),
     /// A time series of samples, keyed by their instant.
     Dynamic {
-        data: BTreeMap<T, Transform<T>>,
+        data: BTreeMap<T, Sample>,
         latest_timestamp: Option<T>,
         max_age: Option<Duration>,
     },
@@ -342,7 +351,13 @@ where
                     Some(current_latest) if current_latest > timestamp => current_latest,
                     _ => timestamp,
                 });
-                data.insert(timestamp, transform);
+                data.insert(
+                    timestamp,
+                    Sample {
+                        translation: transform.translation(),
+                        rotation: transform.rotation(),
+                    },
+                );
                 remove_expired(data, *latest_timestamp, *max_age);
             }
             _ => return Err(InsertError::StaticDynamicConflict),
@@ -392,8 +407,22 @@ where
         let (before, after) = self.get_nearest(&timestamp);
 
         match (before, after) {
-            (Some(before), Some(after)) => Transform::interpolate(before.1, after.1, timestamp)
-                .map_err(GetError::Interpolation),
+            (Some((start, before)), Some((end, after))) => {
+                let (Some(parent), Some(child)) = (&self.parent, &self.child) else {
+                    return Err(GetError::NoTransformAvailable);
+                };
+                // Both samples came from validated inserts; the pinned
+                // frames and map keys preserve their original metadata.
+                Transform::unvalidated(
+                    parent.clone(),
+                    child.clone(),
+                    before.translation,
+                    before.rotation,
+                    Stamp::At(*start),
+                )
+                .interpolate_to(after.translation, after.rotation, *start, *end, timestamp)
+                .map_err(GetError::Interpolation)
+            }
             _ => match (data.first_key_value(), data.last_key_value()) {
                 (Some((first, _)), Some((last, _))) => Err(GetError::OutOfRange {
                     start: *first,
@@ -489,7 +518,7 @@ where
 /// older than the threshold, so skipping the sweep entirely is the correct
 /// behavior — the `checked_sub` failure is deliberately not an error.
 fn remove_expired<T>(
-    data: &mut BTreeMap<T, Transform<T>>,
+    data: &mut BTreeMap<T, Sample>,
     latest_timestamp: Option<T>,
     max_age: Option<Duration>,
 ) where

--- a/src/core/buffer/tests.rs
+++ b/src/core/buffer/tests.rs
@@ -272,6 +272,15 @@ mod buffer_tests {
         assert!(buffer.get(t).is_ok());
     }
 
+    fn assert_sample(
+        (timestamp, sample): (&Timestamp, &crate::core::buffer::Sample),
+        expected: &Transform,
+    ) {
+        assert_eq!(Stamp::At(*timestamp), expected.timestamp());
+        assert_eq!(sample.translation, expected.translation());
+        assert_eq!(sample.rotation, expected.rotation());
+    }
+
     #[test]
     fn get_nearest() {
         let mut buffer = Buffer::dynamic();
@@ -290,36 +299,36 @@ mod buffer_tests {
 
         // Exact match
         let (before, after) = buffer.get_nearest(&t2);
-        assert_eq!(before.unwrap(), (&t2, &p2));
-        assert_eq!(after.unwrap(), (&t2, &p2));
+        assert_sample(before.unwrap(), &p2);
+        assert_sample(after.unwrap(), &p2);
 
         // Between two points
         let p_mid = (t1 + Duration::from_millis(500)).unwrap();
         let (before, after) = buffer.get_nearest(&p_mid);
-        assert_eq!(before.unwrap(), (&t1, &p1));
-        assert_eq!(after.unwrap(), (&t2, &p2));
+        assert_sample(before.unwrap(), &p1);
+        assert_sample(after.unwrap(), &p2);
 
         // Before first point
         let p_0 = (t1 - Duration::from_secs(1)).unwrap();
         let (before, after) = buffer.get_nearest(&p_0);
-        assert_eq!(before, None);
-        assert_eq!(after.unwrap(), (&t1, &p1));
+        assert!(before.is_none());
+        assert_sample(after.unwrap(), &p1);
 
         // After last point
         let p_4 = (t3 + Duration::from_secs(1)).unwrap();
         let (before, after) = buffer.get_nearest(&p_4);
-        assert_eq!(before.unwrap(), (&t3, &p3));
-        assert_eq!(after, None);
+        assert_sample(before.unwrap(), &p3);
+        assert!(after.is_none());
 
         // Exactly at first point
         let (before, after) = buffer.get_nearest(&t1);
-        assert_eq!(before.unwrap(), (&t1, &p1));
-        assert_eq!(after.unwrap(), (&t1, &p1));
+        assert_sample(before.unwrap(), &p1);
+        assert_sample(after.unwrap(), &p1);
 
         // Exactly at last point
         let (before, after) = buffer.get_nearest(&t3);
-        assert_eq!(before.unwrap(), (&t3, &p3));
-        assert_eq!(after.unwrap(), (&t3, &p3));
+        assert_sample(before.unwrap(), &p3);
+        assert_sample(after.unwrap(), &p3);
     }
 
     #[test]
@@ -385,16 +394,16 @@ mod buffer_tests {
         // Before the point
         let (before, after) = buffer.get_nearest(&(t - Duration::from_secs(1)).unwrap());
         assert!(before.is_none());
-        assert_eq!(after.unwrap(), (&t, &point));
+        assert_sample(after.unwrap(), &point);
 
         // Exact match
         let (before, after) = buffer.get_nearest(&t);
-        assert_eq!(before.unwrap(), (&t, &point));
-        assert_eq!(after.unwrap(), (&t, &point));
+        assert_sample(before.unwrap(), &point);
+        assert_sample(after.unwrap(), &point);
 
         // After the point
         let (before, after) = buffer.get_nearest(&(t + Duration::from_secs(1)).unwrap());
-        assert_eq!(before.unwrap(), (&t, &point));
+        assert_sample(before.unwrap(), &point);
         assert!(after.is_none());
     }
 

--- a/src/core/registry/mod.rs
+++ b/src/core/registry/mod.rs
@@ -1149,21 +1149,23 @@ where
         walk_failure: &mut Option<(String, GetError<T>)>,
     ) -> Option<VecDeque<Transform<T>>> {
         let mut transforms = VecDeque::new();
-        let mut current_frame: String = from.into();
+        let mut current_frame = from;
 
         // The frame tree is acyclic by construction (cycles are rejected at
         // insertion), so the walk visits every frame at most once and
         // terminates at a root.
-        while let Some(frame_buffer) = data.get(&current_frame) {
+        while let Some((frame_buffer, parent)) = data
+            .get(current_frame)
+            .and_then(|buffer| buffer.parent().map(|parent| (buffer, parent)))
+        {
             match frame_buffer.get(timestamp) {
                 Ok(tf) => {
-                    current_frame.clear();
-                    current_frame.push_str(tf.parent());
+                    current_frame = parent;
                     transforms.push_back(tf);
                 }
                 Err(source) => {
                     if walk_failure.is_none() {
-                        *walk_failure = Some((current_frame.clone(), source));
+                        *walk_failure = Some((current_frame.into(), source));
                     }
                     break;
                 }

--- a/src/geometry/transform/mod.rs
+++ b/src/geometry/transform/mod.rs
@@ -412,21 +412,34 @@ where
             });
         }
 
+        from.clone()
+            .interpolate_to(to.translation, to.rotation, from_time, to_time, timestamp)
+    }
+
+    /// Interpolates geometry after the caller has checked frames, dynamic
+    /// stamps, and the requested range. The buffer stores those invariants
+    /// once per edge, so it can use the same arithmetic without rebuilding
+    /// a second transform and allocating its frame names.
+    pub(crate) fn interpolate_to(
+        mut self,
+        translation: Vector3,
+        rotation: Quaternion,
+        from_time: T,
+        to_time: T,
+        timestamp: T,
+    ) -> Result<Self, TransformError> {
         let range = to_time.duration_since(from_time)?;
         if range.is_zero() {
-            return Ok(from.clone());
+            return Ok(self);
         }
 
         let diff = timestamp.duration_since(from_time)?;
         let ratio = diff.as_secs_f64() / range.as_secs_f64();
 
-        Ok(Self::unvalidated(
-            from.parent.clone(),
-            from.child.clone(),
-            (1.0 - ratio) * from.translation + ratio * to.translation,
-            from.rotation.slerp(to.rotation, ratio),
-            Stamp::At(timestamp),
-        ))
+        self.translation = (1.0 - ratio) * self.translation + ratio * translation;
+        self.rotation = self.rotation.slerp(rotation, ratio);
+        self.timestamp = Stamp::At(timestamp);
+        Ok(self)
     }
 
     /// Computes the inverse of the transform: the same relationship read the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,22 +210,18 @@
 //!   restriction lints.
 //!   In `no_std` builds, allocation failure aborts via the global
 //!   allocation error handler, as with any `alloc`-based crate: size the
-//!   heap for `max_age` times the insert rate times about 320 B per stored
-//!   sample, measured on x86-64, or bound growth with
-//!   `Registry::remove_transforms_before`. That coefficient holds while
-//!   both frame names are 32 characters or shorter: every sample owns a
-//!   copy of both names, and each adds another 32 B per sample for every
-//!   further 32 characters, so a ROS-style pair of 45-character names
-//!   costs about 385 B instead. 32-bit targets are smaller only at equal
-//!   name length — the names themselves cost the same. The README's
-//!   supported-envelope table turns that coefficient into rates and chain
-//!   depths per platform.
+//!   heap for the retained sample count, map overhead, and per-frame names.
+//!   A dynamic sample stores 56 B of geometry plus its `T` map key; an
+//!   x86-64 measurement with `Timestamp` and 10,000 sequential inserts used
+//!   about 122 B of requested heap per sample, before allocator overhead.
+//!   Measure the actual allocator and workload when sizing a target heap.
 //! - **Checked arithmetic**: all time arithmetic is checked; overflow and
 //!   underflow surface as errors, never as wraparound.
-//! - **Reproducible float math**: `sqrt`, `sin`, and `acos` come from `libm`
+//! - **Same math in both feature modes**: `sqrt`, `sin`, and `acos` come from `libm`
 //!   whether or not `std` is enabled, never from the platform's math
-//!   library, so the same inputs give bit-identical results on a host and on
-//!   the target it replays.
+//!   library. Tests pin interpolated rotations bit for bit in both feature
+//!   modes on the test host; bare-metal builds do not measure cross-device
+//!   replay.
 //! - **Validated inputs**: a `Transform` is validated where it is built —
 //!   the constructors and the `serde` `Deserialize` impl reject non-finite
 //!   values and non-unit rotations, and the private fields keep a built one

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -387,3 +387,65 @@ proptest! {
         );
     }
 }
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    #[test]
+    fn dynamic_history_matches_a_reference_map_after_upserts_expiry_and_cleanup(
+        max_age in prop::option::of(0_u64..64),
+        operations in prop::collection::vec((0_u8..5, 0_u64..128, -100_i32..100), 1..100),
+    ) {
+        let mut registry = max_age.map_or_else(
+            Registry::new,
+            |age| Registry::with_max_age(core::time::Duration::from_nanos(age)),
+        );
+        let mut reference = std::collections::BTreeMap::new();
+        let mut latest: Option<u64> = None;
+        let mut exists = false;
+        for (operation, nanos, coordinate) in operations {
+            if operation == 0 {
+                registry.remove_transforms_before(Timestamp::from_nanos(nanos));
+                reference.retain(|at, _| *at >= nanos);
+                latest = reference.last_key_value().map(|(&at, _)| at);
+            } else {
+                let transform = Transform::new(
+                    "parent", "child",
+                    Vector3::new(f64::from(coordinate), -0.0, 0.25),
+                    Quaternion::identity(),
+                    Stamp::At(Timestamp::from_nanos(nanos)),
+                ).unwrap();
+                registry.add_transform(transform.clone()).unwrap();
+                exists = true;
+                reference.insert(nanos, transform);
+                latest = Some(latest.map_or(nanos, |old| old.max(nanos)));
+                if let Some(cutoff) = latest.zip(max_age).and_then(|(at, age)| at.checked_sub(age)) {
+                    reference.retain(|at, _| *at >= cutoff);
+                }
+            }
+            for requested in [0, nanos, 32, 64, 96, 127] {
+                let stamp = Timestamp::from_nanos(requested);
+                let actual = registry.get_transform("parent", "child", stamp);
+                match (reference.range(..=requested).next_back(), reference.range(requested..).next()) {
+                    (Some((_, before)), Some((_, after))) => {
+                        let expected = Transform::interpolate(before, after, stamp).unwrap();
+                        prop_assert_eq!(actual.unwrap(), expected);
+                    }
+                    _ if exists => {
+                        let expected_range = reference.first_key_value().zip(reference.last_key_value())
+                            .map(|((&start, _), (&end, _))| (Timestamp::from_nanos(start), Timestamp::from_nanos(end)));
+                        match actual.unwrap_err() {
+                            RegistryError::NotFoundAt { frame, requested, covered, .. } => {
+                                prop_assert_eq!(frame, "child");
+                                prop_assert_eq!(requested, stamp);
+                                prop_assert_eq!(covered, expected_range);
+                            }
+                            other => prop_assert!(false, "unexpected error: {other:?}"),
+                        }
+                    }
+                    _ => prop_assert!(matches!(actual, Err(RegistryError::UnknownFrame(_)))),
+                }
+            }
+        }
+    }
+}

--- a/tests/v2_compatibility.rs
+++ b/tests/v2_compatibility.rs
@@ -1,0 +1,186 @@
+//! Public behavior that internal storage and traversal changes must preserve.
+
+use core::time::Duration;
+use transforms::{
+    Registry,
+    errors::{RegistryError, TransformError},
+    geometry::{Quaternion, Transform, Vector3},
+    time::{Stamp, Timestamp},
+};
+
+fn sample(
+    parent: &str,
+    child: &str,
+    nanos: u64,
+) -> Transform {
+    Transform::new(
+        parent,
+        child,
+        Vector3::new(-0.0, 2.0, -3.0),
+        Quaternion::from_wxyz(1.0 - 9e-7, 0.0, 0.0, 0.0),
+        Stamp::At(Timestamp::from_nanos(nanos)),
+    )
+    .unwrap()
+}
+
+#[test]
+fn disconnected_lookup_preserves_sampling_failure_precedence() {
+    let mut registry = Registry::new();
+    registry.add_transform(sample("a", "b", 1)).unwrap();
+    registry.add_transform(sample("x", "y", 1)).unwrap();
+    assert!(matches!(
+        registry.get_transform("b", "y", Timestamp::from_nanos(2)),
+        Err(RegistryError::NotFoundAt { frame, .. }) if frame == "b"
+    ));
+    assert!(matches!(
+        registry.latest_common_time("b", "y"),
+        Err(RegistryError::Disconnected { .. })
+    ));
+}
+
+#[test]
+fn failed_lookup_preserves_failure_above_common_ancestor() {
+    let mut registry = Registry::new();
+    for (parent, child, nanos) in [
+        ("root", "common", 1),
+        ("common", "target", 2),
+        ("common", "source", 1),
+    ] {
+        registry
+            .add_transform(sample(parent, child, nanos))
+            .unwrap();
+    }
+    assert!(matches!(
+        registry.get_transform("target", "source", Timestamp::from_nanos(2)),
+        Err(RegistryError::NotFoundAt { frame, .. }) if frame == "common"
+    ));
+}
+
+#[test]
+fn exact_sample_preserves_signed_zero_and_accepted_rotation_norm() {
+    let stored = sample("parent", "child", 7);
+    let mut registry = Registry::new();
+    registry.add_transform(stored.clone()).unwrap();
+    let found = registry
+        .get_transform("parent", "child", Timestamp::from_nanos(7))
+        .unwrap();
+    assert_eq!(found, stored);
+    assert_eq!(found.translation().x.to_bits(), (-0.0_f64).to_bits());
+    assert_eq!(found.rotation().w.to_bits(), (1.0_f64 - 9e-7).to_bits());
+}
+
+#[test]
+fn attaching_an_existing_root_changes_descendant_depth() {
+    let mut registry = Registry::new();
+    registry.add_transform(sample("root", "leaf", 1)).unwrap();
+    registry.add_transform(sample("world", "root", 1)).unwrap();
+    let found = registry
+        .get_transform("world", "leaf", Timestamp::from_nanos(1))
+        .unwrap();
+    assert_eq!(found.parent(), "world");
+    assert_eq!(found.child(), "leaf");
+    assert!(registry.remove_frame("root"));
+    assert!(matches!(
+        registry.get_transform("world", "leaf", Timestamp::from_nanos(1)),
+        Err(RegistryError::UnknownFrame(frame)) if frame == "world"
+    ));
+    assert!(
+        registry
+            .get_transform("root", "leaf", Timestamp::from_nanos(1))
+            .is_ok()
+    );
+}
+
+#[test]
+fn unbounded_default_interpolates_across_long_gaps() {
+    let mut registry = Registry::default();
+    registry
+        .add_transform(sample("parent", "child", 0))
+        .unwrap();
+    registry
+        .add_transform(sample("parent", "child", 30_000_000_000))
+        .unwrap();
+    assert!(
+        registry
+            .get_transform("parent", "child", Timestamp::from_nanos(15_000_000_000))
+            .is_ok()
+    );
+}
+
+#[test]
+fn right_identity_retains_v2_composition_error() {
+    let identity = Transform::new(
+        "child",
+        "child",
+        Vector3::zero(),
+        Quaternion::identity(),
+        Stamp::At(Timestamp::from_nanos(1)),
+    )
+    .unwrap();
+    assert!(matches!(
+        sample("parent", "child", 1) * identity,
+        Err(TransformError::SameFrameMultiplication { frame }) if frame == "child"
+    ));
+}
+
+#[test]
+fn cross_time_result_keeps_only_target_stamp_and_remains_insertable() {
+    let mut registry = Registry::new();
+    registry
+        .add_transform(sample("world", "source", 1))
+        .unwrap();
+    registry
+        .add_transform(sample("world", "target", 2))
+        .unwrap();
+    let found = registry
+        .get_transform_at(
+            "target",
+            Timestamp::from_nanos(2),
+            "source",
+            Timestamp::from_nanos(1),
+            "world",
+        )
+        .unwrap();
+    assert_eq!(found.timestamp(), Stamp::At(Timestamp::from_nanos(2)));
+    let mut receiver = Registry::new();
+    receiver.add_transform(found).unwrap();
+    assert!(
+        receiver
+            .get_transform("target", "source", Timestamp::from_nanos(2))
+            .is_ok()
+    );
+}
+
+#[test]
+fn timestamp_operators_remain_usable_in_typed_downstream_code() {
+    let added: Result<Timestamp, _> = Timestamp::zero() + Duration::from_nanos(3);
+    let subtracted: Result<Timestamp, _> = added.unwrap() - Duration::from_nanos(1);
+    let elapsed: Result<Duration, _> = subtracted.unwrap() - Timestamp::zero();
+    assert_eq!(elapsed.unwrap(), Duration::from_nanos(2));
+}
+
+#[test]
+fn constant_dynamic_reference_is_accepted_as_a_fixed_frame() {
+    let mut registry = Registry::new();
+    for (parent, child, nanos) in [
+        ("root", "reference", 1),
+        ("root", "reference", 2),
+        ("reference", "source", 1),
+        ("reference", "target", 2),
+    ] {
+        registry
+            .add_transform(sample(parent, child, nanos))
+            .unwrap();
+    }
+    assert!(
+        registry
+            .get_transform_at(
+                "target",
+                Timestamp::from_nanos(2),
+                "source",
+                Timestamp::from_nanos(1),
+                "reference",
+            )
+            .is_ok()
+    );
+}


### PR DESCRIPTION
Dynamic histories currently repeat both frame names in every sample, and lookup walks copy names into temporary strings. Store only translation and rotation under timestamp keys, reconstruct transforms from the buffer's validated frame pins, and borrow those pins during traversal.

The public API, interpolation arithmetic, insertion validation, error precedence, and serde representation are preserved. In the measured 10,000-sample x86-64 fixtures, requested heap drops from 2.56 MB to 1.22 MB with eight-character names and from 4.96 MB to 1.22 MB with 128-character names. Single-hop ancestor lookups drop from five allocations to three; four-hop lookups from eleven to nine.

Includes nine compatibility witnesses, a reference-model property test, reproducible measurements and a feasibility report. Documentation distinguishes host measurements from embedded compilation coverage, and the changelog records the improvements under v2.1.3 (Unreleased).

Validation:

- Full `tests/test_all.sh` gate passes on the branch based on released v2.1.2, including all feature combinations, golden vectors, frozen serde bytes, examples, benchmarks, and ARM bare-metal builds.
- Stable 1.98 clippy and Rust 1.85.1 checks pass in all four feature combinations; RISC-V builds pass with and without serde.
- `cargo-semver-checks --release-type patch` passes against v2.1.2 in all four feature combinations: 223 passing checks and 31 skipped per run.
- Baseline and candidate produce identical 278,880-line differential traces, also with `no_std`.

Resource measurements are host fixtures, not MCU timing or worst-case memory guarantees. Detailed evidence and reproduction commands are in `analysis/v2-feasibility/REPORT.md`.
